### PR TITLE
fix: iOS accept connect function password argument to be nil

### DIFF
--- a/packages/wifi_iot/ios/Classes/SwiftWifiIotPlugin.swift
+++ b/packages/wifi_iot/ios/Classes/SwiftWifiIotPlugin.swift
@@ -121,7 +121,7 @@ public class SwiftWifiIotPlugin: NSObject, FlutterPlugin {
     private func connect(call: FlutterMethodCall, result: @escaping FlutterResult) {
         let sSSID = (call.arguments as? [String : AnyObject])?["ssid"] as! String
         let _ = (call.arguments as? [String : AnyObject])?["bssid"] as? String? // not used
-        let sPassword = (call.arguments as? [String : AnyObject])?["password"] as! String?
+        let sPassword = (call.arguments as? [String : AnyObject])?["password"] as? String? ?? nil
         let bJoinOnce = (call.arguments as? [String : AnyObject])?["join_once"] as! Bool?
         let sSecurity = (call.arguments as? [String : AnyObject])?["security"] as! String?
         


### PR DESCRIPTION
When calling connect function with iOS without providing password the app crashed because it was excepting value. 

Now  you can join open wifi networks also with iOS .