### PR TITLE
docs(wifi_scan): improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Flutter plugin for basic WiFi information and functionalities.
 ### `wifi_scan`
 > [![wifi_scan][scan_workflow_badge]][scan_workflow] [![wifi_scan][scan_pub_badge]][scan_pub] [![pub points][scan_pub_points_badge]][scan_pub_points]
 
-Flutter plugin to scan for WiFi access points.
+Flutter plugin to scan for nearby visible WiFi access points.
 
 [[View Source][scan_code]]
 

--- a/packages/wifi_scan/README.md
+++ b/packages/wifi_scan/README.md
@@ -28,7 +28,7 @@ This plugin allows Flutter apps to trigger WiFi scan and get scanned results.
 | Platform | Status | Min. Version |  API  | Notes |
 | :------: | :----: |:------------:| :---: |:-----:|
 | **Android** | ✔️ | 16 (J) | Scan related APIs in [`WifiManager`][android_WifiManager] *[[Guide][android_guide]]* | For SDK >= 26(O) scans are [throttled][android_throttling]. |
-| **iOS** | ✔️ | 9.0 | No API available | Dummy implementation with [sane static returns][ios_dummy]. |
+| **iOS** | ✔️ | 9.0 | No API available | [Stub implementation][ios_stub] with sane static returns. |
 
 ## Usage
 The entry point for the plugin is the singleton instance `WiFiScan.instance`.
@@ -48,7 +48,8 @@ switch(can) {
 }
 ```
 
-For more details, you can read documentation of [`WiFiScan.startScan`][doc_startScan], [`WiFiScan.canStartScan`][doc_canStartScan] and [`CanStartScan`][doc_enum_CanStartScan].
+For more details, you can read documentation of [`WiFiScan.startScan`][doc_startScan], 
+[`WiFiScan.canStartScan`][doc_canStartScan] and [`CanStartScan`][doc_enum_CanStartScan].
 
 ### Get scanned results
 You can get scanned results with `WiFiScan.getScannedResults` API, as shown below:
@@ -67,7 +68,10 @@ switch(can) {
 
 > **NOTE:** `getScannedResults` API can be used independently of `startScan` API. This returns the latest available scanned results.
 
-For more details, you can read documentation of [`WiFiScan.getScannedResults`][doc_getScannedResults], [`WiFiAccessPoint`][doc_WiFiAccessPoint], [`WiFiScan.canGetScannedResults`][doc_canGetScannedResults] and [`CanGetScannedResults`][doc_enum_CanGetScannedResults].
+For more details, you can read documentation of [`WiFiScan.getScannedResults`][doc_getScannedResults], 
+[`WiFiAccessPoint`][doc_WiFiAccessPoint], 
+[`WiFiScan.canGetScannedResults`][doc_canGetScannedResults] and 
+[`CanGetScannedResults`][doc_enum_CanGetScannedResults].
 
 ### Get notified when scanned results available
 You can get notified when new scanned results are available, as shown below:
@@ -100,11 +104,16 @@ dispose() {
 }
 ```
 
-Additionally, `WiFiScan.onScannedResultsAvailable` API can also be used with Flutter's [`StreamBuilder`][flutter_StreamBuilder] widget.
+Additionally, `WiFiScan.onScannedResultsAvailable` API can also be used with Flutter's 
+[`StreamBuilder`][flutter_StreamBuilder] widget.
 
 > **NOTE:** `onScannedResultsAvailable` API can be used  independently of `startScan` API. The notification can also be result of a full scan performed by platform or other app.
 
-For more details, you can read documentation of [`WiFiScan.onScannedResultsAvailable`][doc_onScannedResultsAvailable], [`WiFiAccessPoint`][doc_WiFiAccessPoint], [`WiFiScan.canGetScannedResults`][doc_canGetScannedResults] and [`CanGetScannedResults`][doc_enum_CanGetScannedResults].
+For more details, you can read documentation of 
+[`WiFiScan.onScannedResultsAvailable`][doc_onScannedResultsAvailable], 
+[`WiFiAccessPoint`][doc_WiFiAccessPoint], 
+[`WiFiScan.canGetScannedResults`][doc_canGetScannedResults] and 
+[`CanGetScannedResults`][doc_enum_CanGetScannedResults].
 
 ## Resources
 - 📖[API docs][docs]
@@ -114,7 +123,8 @@ For more details, you can read documentation of [`WiFiScan.onScannedResultsAvail
 
 Please file WiFiFlutter specific issues, bugs, or feature requests in our [issue tracker][wf_issue].
 
-To contribute a change to this plugin, please review plugin [checklist for 1.0][checklist], our [contribution guide][wf_contrib] and open a [pull request][wf_pull].
+To contribute a change to this plugin, please review plugin [checklist for 1.0][checklist], our 
+[contribution guide][wf_contrib] and open a [pull request][wf_pull].
 
 <!-- links -->
 [wf_home]: https://wifi.flutternetwork.dev/
@@ -141,4 +151,4 @@ To contribute a change to this plugin, please review plugin [checklist for 1.0][
 [android_throttling]: https://developer.android.com/guide/topics/connectivity/wifi-scan#wifi-scan-throttling
 [android_WifiManager]: https://developer.android.com/reference/android/net/wifi/WifiManager
 
-[ios_dummy]: https://github.com/flutternetwork/WiFiFlutter/blob/master/packages/wifi_scan/ios/Classes/SwiftWifiScanPlugin.swift
+[ios_stub]: https://github.com/flutternetwork/WiFiFlutter/blob/master/packages/wifi_scan/ios/Classes/SwiftWifiScanPlugin.swift

--- a/packages/wifi_scan/README.md
+++ b/packages/wifi_scan/README.md
@@ -19,7 +19,7 @@
 </p>  
 
 ---
-This plugin allows Flutter apps to trigger WiFi scan and get scanned results.
+This plugin allows Flutter apps to scan for nearby visible WiFi access points.
 
 > This plugin is part of [WiFiFlutter][wf_home] suite, enabling various WiFi services for Flutter. 
 

--- a/packages/wifi_scan/README.md
+++ b/packages/wifi_scan/README.md
@@ -117,7 +117,7 @@ For more details, you can read documentation of
 
 ## Resources
 - 📖[API docs][docs]
-- 💻[Example app][example]
+- 💡[Example app][example]
 
 ## Issues and feedback
 

--- a/packages/wifi_scan/ios/Classes/SwiftWifiScanPlugin.swift
+++ b/packages/wifi_scan/ios/Classes/SwiftWifiScanPlugin.swift
@@ -1,7 +1,7 @@
 import Flutter
 
 // Since no API for scanning or getting scanned results in iOS.
-// This class is just a "dummy" implementation with sane returns.
+// This class is just a "stub" implementation with sane returns.
 // It is maintained to avoid `MissingPluginException`.
 public class SwiftWifiScanPlugin: NSObject, FlutterPlugin {
   public static func register(with registrar: FlutterPluginRegistrar) {
@@ -15,7 +15,7 @@ public class SwiftWifiScanPlugin: NSObject, FlutterPlugin {
         name: "wifi_scan/onScannedResultsAvailable",
         binaryMessenger: registrar.messenger()
     )
-    eventChannel.setStreamHandler(DummyStreamHandler())
+    eventChannel.setStreamHandler(StubStreamHandler())
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
@@ -35,7 +35,7 @@ public class SwiftWifiScanPlugin: NSObject, FlutterPlugin {
 }
 
 
-class DummyStreamHandler: NSObject, FlutterStreamHandler{
+class StubStreamHandler: NSObject, FlutterStreamHandler{
     func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
         return nil
     }

--- a/packages/wifi_scan/ios/wifi_scan.podspec
+++ b/packages/wifi_scan/ios/wifi_scan.podspec
@@ -5,9 +5,9 @@
 Pod::Spec.new do |s|
   s.name             = 'wifi_scan'
   s.version          = '0.0.1'
-  s.summary          = 'Flutter plugin to scan for WiFi access points.'
+  s.summary          = 'Flutter plugin to scan for nearby visible WiFi access points.'
   s.description      = <<-DESC
-Flutter plugin to scan for WiFi access points.
+Flutter plugin to scan for nearby visible WiFi access points.
                        DESC
   s.homepage         = 'https://wifi.flutternetwork.dev'
   s.license          = { :file => '../LICENSE' }

--- a/packages/wifi_scan/lib/src/accesspoint.dart
+++ b/packages/wifi_scan/lib/src/accesspoint.dart
@@ -5,19 +5,19 @@ enum WiFiStandards {
   /// Unknown.
   unkown,
 
-  /// Wi-Fi 802.11a/b/g.
+  /// [Wi-Fi 802.11a/b/g](https://en.wikipedia.org/wiki/IEEE_802.11).
   legacy,
 
-  /// Wi-Fi 802.11n (Wi-Fi 4).
+  /// [Wi-Fi 802.11n (Wi-Fi 4)](https://en.wikipedia.org/wiki/IEEE_802.11n).
   n,
 
-  /// Wi-Fi 802.11ac (Wi-Fi 5).
+  /// [Wi-Fi 802.11ac (Wi-Fi 5)](https://en.wikipedia.org/wiki/IEEE_802.11ac).
   ac,
 
-  /// Wi-Fi 802.11ax (Wi-Fi 6).
+  /// [Wi-Fi 802.11ax (Wi-Fi 6)](https://en.wikipedia.org/wiki/IEEE_802.11ax).
   ax,
 
-  /// Wi-Fi 802.11ad.
+  /// [Wi-Fi 802.11ad](https://en.wikipedia.org/wiki/IEEE_802.11ad).
   ad,
 }
 
@@ -143,7 +143,8 @@ class WiFiAccessPoint {
   /// Only available on Passpoint network and if published by access point.
   final String? venueName;
 
-  /// Indicates if the access point can respond to IEEE 802.11mc (WiFi RTT)
+  /// Indicates if the access point can respond to
+  /// [IEEE 802.11mc (WiFi RTT)](https://en.wikipedia.org/wiki/IEEE_802.11mc)
   /// ranging requests.
   final bool? is80211mcResponder;
 

--- a/packages/wifi_scan/lib/src/can.dart
+++ b/packages/wifi_scan/lib/src/can.dart
@@ -5,7 +5,7 @@ enum CanStartScan {
   /// Functionality is not supported.
   notSupported,
 
-  /// It is ok to call functionality.
+  /// It is ok to call the functionality.
   yes,
 
   /// Location permission is required.
@@ -47,7 +47,7 @@ CanStartScan _deserializeCanStartScan(int? canCode) {
 
 /// Result for [WiFiScan.canGetScannedResults] method.
 enum CanGetScannedResults {
-  /// Functionality is not supported.
+  /// Functionality is not the supported.
   notSupported,
 
   /// It is ok to call functionality.

--- a/packages/wifi_scan/lib/wifi_scan.dart
+++ b/packages/wifi_scan/lib/wifi_scan.dart
@@ -35,7 +35,7 @@ class WiFiScan {
 
   /// Request a Wi-Fi scan.
   ///
-  /// Return value indicates if the "scan" is being triggered.
+  /// Return value indicates if the "scan" trigger successed.
   ///
   /// Should call [canStartScan] as a check before calling this method.
   Future<bool> startScan() async {

--- a/packages/wifi_scan/pubspec.yaml
+++ b/packages/wifi_scan/pubspec.yaml
@@ -1,5 +1,5 @@
 name: wifi_scan
-description: Flutter plugin to scan for WiFi access points.
+description: Flutter plugin to scan for nearby visible WiFi access points.
 version: 0.1.0
 homepage: https://github.com/alternadom/WiFiFlutter/tree/master/packages/wifi_scan
 


### PR DESCRIPTION
- updated "plugin description", to be >60 char, pub.dev requirement
- referring to iOS implementation as "stub" and not "dummy"
- reamde: line breaks wherever possible, before `[]()`