### PR TITLE
fix(wifi_iot,android): `disconnect` - returning result properly 

### DIFF
--- a/packages/wifi_iot/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
+++ b/packages/wifi_iot/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
@@ -282,12 +282,7 @@ public class WifiIotPlugin
         getIP(poResult);
         break;
       case "removeWifiNetwork":
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) removeWifiNetwork(poCall, poResult);
-        else
-          poResult.error(
-              "Error",
-              "removeWifiNetwork not supported for Android SDK " + Build.VERSION.SDK_INT,
-              null);
+        removeWifiNetwork(poCall, poResult);
         break;
       case "isRegisteredWifiNetwork":
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q)
@@ -1109,18 +1104,35 @@ public class WifiIotPlugin
     if (prefix_ssid.equals("")) {
       poResult.error("Error", "No prefix SSID was given!", null);
     }
+    boolean removed = false;
 
-    List<android.net.wifi.WifiConfiguration> mWifiConfigList = moWiFi.getConfiguredNetworks();
-    for (android.net.wifi.WifiConfiguration wifiConfig : mWifiConfigList) {
-      String comparableSSID = ('"' + prefix_ssid); //Add quotes because wifiConfig.SSID has them
-      if (wifiConfig.SSID.startsWith(comparableSSID)) {
-        moWiFi.removeNetwork(wifiConfig.networkId);
-        moWiFi.saveConfiguration();
-        poResult.success(true);
-        return;
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+      List<android.net.wifi.WifiConfiguration> mWifiConfigList = moWiFi.getConfiguredNetworks();
+      for (android.net.wifi.WifiConfiguration wifiConfig : mWifiConfigList) {
+        String comparableSSID = ('"' + prefix_ssid); //Add quotes because wifiConfig.SSID has them
+        if (wifiConfig.SSID.startsWith(comparableSSID)) {
+          moWiFi.removeNetwork(wifiConfig.networkId);
+          moWiFi.saveConfiguration();
+          removed = true;
+          break;
+        }
       }
     }
-    poResult.success(false);
+
+    // remove network suggestion
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      List<WifiNetworkSuggestion> suggestions = moWiFi.getNetworkSuggestions();
+      List<WifiNetworkSuggestion> removeSuggestions = new ArrayList();
+      for (int i = 0, suggestionsSize = suggestions.size(); i < suggestionsSize; i++) {
+        WifiNetworkSuggestion suggestion = suggestions.get(i);
+        if (suggestion.getSsid().startsWith(prefix_ssid)) {
+          removeSuggestions.add(suggestion);
+        }
+      }
+      final int networksRemoved = moWiFi.removeNetworkSuggestions(removeSuggestions);
+      removed = networksRemoved == WifiManager.STATUS_NETWORK_SUGGESTIONS_SUCCESS;
+    }
+    poResult.success(removed);
   }
 
   /// This method will remove the WiFi network as per the passed SSID from the device list

--- a/packages/wifi_iot/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
+++ b/packages/wifi_iot/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
@@ -1024,29 +1024,27 @@ public class WifiIotPlugin
 
   /// Disconnect current Wifi.
   private void disconnect(Result poResult) {
+    boolean disconnected = false;
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
       //noinspection deprecation
-      final boolean disconnected = moWiFi.disconnect();
-      poResult.success(disconnected);
-      return;
+      disconnected = moWiFi.disconnect();
     } else {
       if (networkCallback != null) {
         final ConnectivityManager connectivityManager =
             (ConnectivityManager) moContext.getSystemService(Context.CONNECTIVITY_SERVICE);
         connectivityManager.unregisterNetworkCallback(networkCallback);
+        networkCallback = null;
+        disconnected = true;
+      } else if (networkSuggestions != null) {
+        final int networksRemoved = moWiFi.removeNetworkSuggestions(networkSuggestions);
+        disconnected = networksRemoved == WifiManager.STATUS_NETWORK_SUGGESTIONS_SUCCESS;
       } else {
         Log.e(
             WifiIotPlugin.class.getSimpleName(),
-            "Can't disconnect from WiFi, networkCallback is null.");
-      }
-
-      if (networkSuggestions != null) {
-        final int networksRemoved = moWiFi.removeNetworkSuggestions(networkSuggestions);
-        poResult.success(networksRemoved == WifiManager.STATUS_NETWORK_SUGGESTIONS_SUCCESS);
-        return;
+            "Can't disconnect from WiFi, networkCallback and networkSuggestions is null.");
       }
     }
-    poResult.success(null);
+    poResult.success(disconnected);
   }
 
   /// This method will return current ssid


### PR DESCRIPTION
+ error log only when `networkCallback` and `networkSuggestions` both are null