### PR TITLE
refactor(wifi_scan)!: not having separate "can" APIs for checks

### DIFF
--- a/packages/wifi_scan/README.md
+++ b/packages/wifi_scan/README.md
@@ -28,7 +28,7 @@ This plugin allows Flutter apps to scan for nearby visible WiFi access points.
 | Platform | Status | Min. Version |  API  | Notes |
 | :------: | :----: |:------------:| :---: |:-----:|
 | **Android** | ✔️ | 16 (J) | Scan related APIs in [`WifiManager`][android_WifiManager] *[[Guide][android_guide]]* | For SDK >= 26(O) scans are [throttled][android_throttling]. |
-| **iOS** | ✔️ | 9.0 | No API available | [Stub implementation][ios_stub] with sane static returns. |
+| **iOS** | ✔️ | 9.0 | [No public API][ios_thread] | [Stub implementation][ios_stub] with sane returns. |
 
 ## Usage
 The entry point for the plugin is the singleton instance `WiFiScan.instance`.
@@ -36,64 +36,62 @@ The entry point for the plugin is the singleton instance `WiFiScan.instance`.
 ### Start scan
 You can trigger full WiFi scan with `WiFiScan.startScan` API, as shown below:
 ```dart
-// check if platform support and necessary requirements
-final can = await WiFiScan.instance.canStartScan(askPermissions: true);
-switch(can) {
-  case CanStartScan.yes:
-    // start full scan async-ly
-    final isScanning = await WiFiScan.instance.startScan();
-    //...
-    break;
-  // ... handle other cases of CanStartScan values
+void _startScan() async {
+  // start full scan async-ly
+  final error = await WiFiScan.instance.startScan(askPermissions: true);
+  if (error != null) {
+    switch(error) {
+      // handle error for values of StartScanErrors
+    }
+  }
 }
 ```
 
 For more details, you can read documentation of [`WiFiScan.startScan`][doc_startScan], 
-[`WiFiScan.canStartScan`][doc_canStartScan] and [`CanStartScan`][doc_enum_CanStartScan].
+[`StartScanErrors`][doc_StartScanErrors] and [`Result<ValueType, ErrorType>`][doc_Result].
 
 ### Get scanned results
 You can get scanned results with `WiFiScan.getScannedResults` API, as shown below:
 ```dart
-// check if platform support and necessary requirements
-final can = await WiFiScan.instance.canGetScannedResults(askPermissions: true);
-switch(can) {
-  case CanGetScannedResults.yes:
-    // get scanned results
-    final accessPoints = await WiFiScan.instance.getScannedResults();
+void _getScannedResults() async {
+  // get scanned results
+  final result = await WiFiScan.instance.getScannedResults(askPermissions: true);
+  if (result.hasError){
+    switch (error){
+      // handle error for values of GetScannedResultErrors
+    }
+  } else {
+    final accessPoints = result.value;
     // ...
-    break;
-  // ... handle other cases of CanGetScannedResults values
+  }
 }
 ```
 
 > **NOTE:** `getScannedResults` API can be used independently of `startScan` API. This returns the latest available scanned results.
 
 For more details, you can read documentation of [`WiFiScan.getScannedResults`][doc_getScannedResults], 
-[`WiFiAccessPoint`][doc_WiFiAccessPoint], 
-[`WiFiScan.canGetScannedResults`][doc_canGetScannedResults] and 
-[`CanGetScannedResults`][doc_enum_CanGetScannedResults].
+[`WiFiAccessPoint`][doc_WiFiAccessPoint], [`GetScannedResultsErrors`][doc_GetScannedResultsErrors] and 
+[`Result<ValueType, ErrorType>`][doc_Result].
 
 ### Get notified when scanned results available
-You can get notified when new scanned results are available, as shown below:
+You can get notified when new scanned results are available with `WiFiScan.onScannedResultsAvailable` API, as shown below:
 ```dart
 // initialize accessPoints and subscription
 List<WiFiAccessPoint> accessPoints = [];
-StreamSubscription<List<WiFiAccessPoint>>? subscription;
+StreamSubscription<Result<List<WiFiAccessPoint>, GetScannedResultErrors>>? subscription;
 
-void _startListeningToScannedResults(){
-// check if platform support and necessary requirements
-  final can = await WiFiScan.instance.canGetScannedResults(askPermissions: true);
-  switch(can) {
-    case CanGetScannedResults.yes:
-      // listen to onScannedResultsAvailable stream
-      subscription = WiFiScan.instance.onScannedResultsAvailable.listen((results) {
-        // update accessPoints
-        setState(() => accessPoints = results);
-      });
-      // ...
-      break;
-    // ... handle other cases of CanGetScannedResults values
-  }
+void _startListeningToScannedResults() async {
+  // listen to onScannedResultsAvailable stream
+  subscription = WiFiScan.instance.onScannedResultsAvailable.listen((result) {
+    if (result.hasError){
+      switch (error){
+      // handle error for values of GetScannedResultErrors
+      }  
+    } else {
+      // update accessPoints
+      setState(() => accessPoints = result.value);
+    }
+  });
 }
 
 // make sure to cancel subscription after you are done
@@ -111,9 +109,8 @@ Additionally, `WiFiScan.onScannedResultsAvailable` API can also be used with Flu
 
 For more details, you can read documentation of 
 [`WiFiScan.onScannedResultsAvailable`][doc_onScannedResultsAvailable], 
-[`WiFiAccessPoint`][doc_WiFiAccessPoint], 
-[`WiFiScan.canGetScannedResults`][doc_canGetScannedResults] and 
-[`CanGetScannedResults`][doc_enum_CanGetScannedResults].
+[`WiFiAccessPoint`][doc_WiFiAccessPoint], [`GetScannedResultsErrors`][doc_GetScannedResultsErrors] and 
+[`Result<ValueType, ErrorType>`][doc_Result].
 
 ## Resources
 - 📖[API docs][docs]
@@ -137,12 +134,11 @@ To contribute a change to this plugin, please review plugin [checklist for 1.0][
 [example]: https://github.com/flutternetwork/WiFiFlutter/tree/master/packages/wifi_scan/example
 
 [doc_startScan]: https://pub.dev/documentation/wifi_scan/latest/wifi_scan/WiFiScan/startScan.html
-[doc_canStartScan]: https://pub.dev/documentation/wifi_scan/latest/wifi_scan/WiFiScan/canStartScan.html
-[doc_enum_CanStartScan]: https://pub.dev/documentation/wifi_scan/latest/wifi_scan/CanStartScan.html
+[doc_StartScanErrors]: https://pub.dev/documentation/wifi_scan/latest/wifi_scan/StartScanErrors.html
+[doc_Result]: https://pub.dev/documentation/wifi_scan/latest/wifi_scan/Result-class.html
 [doc_getScannedResults]: https://pub.dev/documentation/wifi_scan/latest/wifi_scan/WiFiScan/getScannedResults.html
 [doc_WiFiAccessPoint]: https://pub.dev/documentation/wifi_scan/latest/wifi_scan/WiFiAccessPoint-class.html
-[doc_canGetScannedResults]: https://pub.dev/documentation/wifi_scan/latest/wifi_scan/WiFiScan/canGetScannedResults.html
-[doc_enum_CanGetScannedResults]: https://pub.dev/documentation/wifi_scan/latest/wifi_scan/CanGetScannedResults.html
+[doc_GetScannedResultsErrors]: https://pub.dev/documentation/wifi_scan/latest/wifi_scan/GetScannedResultsErrors.html
 [doc_onScannedResultsAvailable]: https://pub.dev/documentation/wifi_scan/latest/wifi_scan/WiFiScan/onScannedResultsAvailable.html
 
 [flutter_StreamBuilder]: https://api.flutter.dev/flutter/widgets/StreamBuilder-class.html
@@ -151,4 +147,5 @@ To contribute a change to this plugin, please review plugin [checklist for 1.0][
 [android_throttling]: https://developer.android.com/guide/topics/connectivity/wifi-scan#wifi-scan-throttling
 [android_WifiManager]: https://developer.android.com/reference/android/net/wifi/WifiManager
 
+[ios_thread]: https://developer.apple.com/forums/thread/39204
 [ios_stub]: https://github.com/flutternetwork/WiFiFlutter/blob/master/packages/wifi_scan/ios/Classes/SwiftWifiScanPlugin.swift

--- a/packages/wifi_scan/android/build.gradle
+++ b/packages/wifi_scan/android/build.gradle
@@ -2,7 +2,7 @@ group 'dev.flutternetwork.wifi.wifi_scan'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         mavenCentral()

--- a/packages/wifi_scan/android/src/main/kotlin/dev/flutternetwork/wifi/wifi_scan/WifiScanPlugin.kt
+++ b/packages/wifi_scan/android/src/main/kotlin/dev/flutternetwork/wifi/wifi_scan/WifiScanPlugin.kt
@@ -186,7 +186,7 @@ class WifiScanPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
                 val mResult = getScannedResults(askPermission)
                 // if error != ASK_FOR_LOC_PERM, send result
                 // else ask for permission - wait for user action - return result based on it
-                if (mResult.getValue("error") != ASK_FOR_LOC_PERM) {
+                if (mResult["error"] != ASK_FOR_LOC_PERM) {
                     result.success(mResult)
                 } else {
                     askForLocationPermission { askResult ->

--- a/packages/wifi_scan/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/wifi_scan/example/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"
+            android:exported="true"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"

--- a/packages/wifi_scan/example/android/build.gradle
+++ b/packages/wifi_scan/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         mavenCentral()

--- a/packages/wifi_scan/example/lib/main.dart
+++ b/packages/wifi_scan/example/lib/main.dart
@@ -85,7 +85,7 @@ class _MyAppState extends State<MyApp> {
                       icon: const Icon(Icons.perm_scan_wifi),
                       label: const Text('SCAN'),
                       // call startScan and reset the ap list
-                      onPressed: () => () async {
+                      onPressed: () async {
                         final error = await WiFiScan.instance.startScan();
                         kShowSnackBar(context, "startScan: ${error ?? 'done'}");
                         setState(() => accessPoints = <WiFiAccessPoint>[]);

--- a/packages/wifi_scan/example/lib/main.dart
+++ b/packages/wifi_scan/example/lib/main.dart
@@ -24,7 +24,7 @@ class _MyAppState extends State<MyApp> {
 
   bool get isStreaming => subscription != null;
 
-  void _handleScannedResults(
+  void _handleScannedResults(BuildContext context,
       Result<List<WiFiAccessPoint>, GetScannedResultsErrors> result) {
     if (result.hasError) {
       kShowSnackBar(context, "Cannot get scanned results: ${result.error}");
@@ -36,7 +36,7 @@ class _MyAppState extends State<MyApp> {
 
   void _startListeningToScanResults(BuildContext context) {
     subscription = WiFiScan.instance.onScannedResultsAvailable
-        .listen((result) => _handleScannedResults(result));
+        .listen((result) => _handleScannedResults(context, result));
   }
 
   void _stopListteningToScanResults() {
@@ -92,11 +92,12 @@ class _MyAppState extends State<MyApp> {
                       },
                     ),
                     ElevatedButton.icon(
-                        icon: const Icon(Icons.refresh),
-                        label: const Text('GET'),
-                        // call getScannedResults and handle the result
-                        onPressed: () async => _handleScannedResults(
-                            await WiFiScan.instance.getScannedResults())),
+                      icon: const Icon(Icons.refresh),
+                      label: const Text('GET'),
+                      // call getScannedResults and handle the result
+                      onPressed: () async => _handleScannedResults(
+                          context, await WiFiScan.instance.getScannedResults()),
+                    ),
                     Row(
                       children: [
                         const Text("STREAM"),

--- a/packages/wifi_scan/example/lib/main.dart
+++ b/packages/wifi_scan/example/lib/main.dart
@@ -57,6 +57,42 @@ class _MyAppState extends State<MyApp> {
         ),
       );
 
+  // build access point tile.
+  Widget _buildAccessPointTile(BuildContext context, WiFiAccessPoint ap) {
+    final title = ap.ssid.isNotEmpty ? ap.ssid : "**EMPTY**";
+    final signalIcon =
+        ap.level >= -80 ? Icons.signal_wifi_4_bar : Icons.signal_wifi_0_bar;
+    return ListTile(
+      visualDensity: VisualDensity.compact,
+      leading: Icon(signalIcon),
+      title: Text(title),
+      subtitle: Text(ap.capabilities),
+      onTap: () => showDialog(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: Text(title),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _buildInfo("BSSDI", ap.bssid),
+              _buildInfo("Capability", ap.capabilities),
+              _buildInfo("frequency", "${ap.frequency}MHz"),
+              _buildInfo("level", ap.level),
+              _buildInfo("standard", ap.standard),
+              _buildInfo("centerFrequency0", "${ap.centerFrequency0}MHz"),
+              _buildInfo("centerFrequency1", "${ap.centerFrequency1}MHz"),
+              _buildInfo("channelWidth", ap.channelWidth),
+              _buildInfo("isPasspoint", ap.isPasspoint),
+              _buildInfo("operatorFriendlyName", ap.operatorFriendlyName),
+              _buildInfo("venueName", ap.venueName),
+              _buildInfo("is80211mcResponder", ap.is80211mcResponder),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
   @override
   void dispose() {
     super.dispose();
@@ -117,52 +153,8 @@ class _MyAppState extends State<MyApp> {
                         ? const Text("NO SCANNED RESULTS")
                         : ListView.builder(
                             itemCount: accessPoints.length,
-                            itemBuilder: (context, i) {
-                              final ap = accessPoints[i];
-                              final title =
-                                  ap.ssid.isNotEmpty ? ap.ssid : "**EMPTY**";
-                              final signalIcon = ap.level >= -80
-                                  ? Icons.signal_wifi_4_bar
-                                  : Icons.signal_wifi_0_bar;
-                              return ListTile(
-                                visualDensity: VisualDensity.compact,
-                                leading: Icon(signalIcon),
-                                title: Text(title),
-                                subtitle: Text(ap.capabilities),
-                                onTap: () => showDialog(
-                                  context: context,
-                                  builder: (context) => AlertDialog(
-                                    title: Text(title),
-                                    content: Column(
-                                      mainAxisSize: MainAxisSize.min,
-                                      children: [
-                                        _buildInfo("BSSDI", ap.bssid),
-                                        _buildInfo(
-                                            "Capability", ap.capabilities),
-                                        _buildInfo(
-                                            "frequency", "${ap.frequency}MHz"),
-                                        _buildInfo("level", ap.level),
-                                        _buildInfo("standard", ap.standard),
-                                        _buildInfo("centerFrequency0",
-                                            "${ap.centerFrequency0}MHz"),
-                                        _buildInfo("centerFrequency1",
-                                            "${ap.centerFrequency1}MHz"),
-                                        _buildInfo(
-                                            "channelWidth", ap.channelWidth),
-                                        _buildInfo(
-                                            "isPasspoint", ap.isPasspoint),
-                                        _buildInfo("operatorFriendlyName",
-                                            ap.operatorFriendlyName),
-                                        _buildInfo("venueName", ap.venueName),
-                                        _buildInfo("is80211mcResponder",
-                                            ap.is80211mcResponder),
-                                      ],
-                                    ),
-                                  ),
-                                ),
-                              );
-                            },
-                          ),
+                            itemBuilder: (context, i) => _buildAccessPointTile(
+                                context, accessPoints[i])),
                   ),
                 ),
               ],

--- a/packages/wifi_scan/ios/Classes/SwiftWifiScanPlugin.swift
+++ b/packages/wifi_scan/ios/Classes/SwiftWifiScanPlugin.swift
@@ -20,14 +20,10 @@ public class SwiftWifiScanPlugin: NSObject, FlutterPlugin {
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
     switch(call.method){
-      case "canStartScan":
-          return result(0) // not supported
       case "startScan":
-          return result(false) // always fails
-      case "canGetScannedResults":
           return result(0) // not supported
       case "getScannedResults":
-          return result([]) // empty results
+          return result(["error": 0]) // not supported
       default:
           return result(FlutterMethodNotImplemented)
     }

--- a/packages/wifi_scan/lib/src/error.dart
+++ b/packages/wifi_scan/lib/src/error.dart
@@ -1,13 +1,10 @@
 part of '../wifi_scan.dart';
 
-/// Result for [WiFiScan.canStartScan] method.
-enum CanStartScan {
+/// Possible errors for [WiFiScan.startScan] method.
+enum StartScanErrors {
   /// Functionality is not supported.
   notSupported,
 
-  /// It is ok to call the functionality.
-  yes,
-
   /// Location permission is required.
   ///
   /// A prompt for permission can be requested.
@@ -25,34 +22,35 @@ enum CanStartScan {
 
   /// Location service needs to be enabled.
   noLocationServiceDisabled,
+
+  /// Failed to trigger scan.
+  failed,
 }
 
-CanStartScan _deserializeCanStartScan(int? canCode) {
-  switch (canCode) {
+StartScanErrors _deserializeStartScanError(int errorCode) {
+  switch (errorCode) {
     case 0:
-      return CanStartScan.notSupported;
+      return StartScanErrors.notSupported;
     case 1:
-      return CanStartScan.yes;
+      return StartScanErrors.noLocationPermissionRequired;
     case 2:
-      return CanStartScan.noLocationPermissionRequired;
+      return StartScanErrors.noLocationPermissionDenied;
     case 3:
-      return CanStartScan.noLocationPermissionDenied;
+      return StartScanErrors.noLocationPermissionUpgradeAccuracy;
     case 4:
-      return CanStartScan.noLocationPermissionUpgradeAccuracy;
+      return StartScanErrors.noLocationServiceDisabled;
     case 5:
-      return CanStartScan.noLocationServiceDisabled;
+      return StartScanErrors.failed;
   }
-  throw UnsupportedError("$canCode cannot be serialized to CanStartScan");
+  throw UnsupportedError("$errorCode cannot be serialized to StartScanError");
 }
 
-/// Result for [WiFiScan.canGetScannedResults] method.
-enum CanGetScannedResults {
+/// Possible errors for [WiFiScan.getScannedResults] and
+/// [WiFiScan.onScannedResultsAvailable] methods.
+enum GetScannedResultsErrors {
   /// Functionality is not the supported.
   notSupported,
 
-  /// It is ok to call functionality.
-  yes,
-
   /// Location permission is required.
   ///
   /// A prompt for permission can be requested.
@@ -72,21 +70,19 @@ enum CanGetScannedResults {
   noLocationServiceDisabled,
 }
 
-CanGetScannedResults _deserializeCanGetScannedResults(int? canCode) {
-  switch (canCode) {
+GetScannedResultsErrors _deserializeGetScannedResultsError(int errorCode) {
+  switch (errorCode) {
     case 0:
-      return CanGetScannedResults.notSupported;
+      return GetScannedResultsErrors.notSupported;
     case 1:
-      return CanGetScannedResults.yes;
+      return GetScannedResultsErrors.noLocationPermissionRequired;
     case 2:
-      return CanGetScannedResults.noLocationPermissionRequired;
+      return GetScannedResultsErrors.noLocationPermissionDenied;
     case 3:
-      return CanGetScannedResults.noLocationPermissionDenied;
+      return GetScannedResultsErrors.noLocationPermissionUpgradeAccuracy;
     case 4:
-      return CanGetScannedResults.noLocationPermissionUpgradeAccuracy;
-    case 5:
-      return CanGetScannedResults.noLocationServiceDisabled;
+      return GetScannedResultsErrors.noLocationServiceDisabled;
   }
   throw UnsupportedError(
-      "$canCode cannot be serialized to CanGetScannedNetworks");
+      "$errorCode cannot be serialized to GetScannedResultsError");
 }

--- a/packages/wifi_scan/lib/src/result.dart
+++ b/packages/wifi_scan/lib/src/result.dart
@@ -1,0 +1,17 @@
+part of '../wifi_scan.dart';
+
+/// Represents either value or error.
+class Result<ValueType, ErrorType> {
+  /// Data.
+  final ValueType? value;
+
+  /// Error.
+  final ErrorType? error;
+
+  const Result._error(this.error) : value = null;
+
+  const Result._value(this.value) : error = null;
+
+  /// Convenient getter to check if holds error.
+  bool get hasError => error != null;
+}

--- a/packages/wifi_scan/lib/wifi_scan.dart
+++ b/packages/wifi_scan/lib/wifi_scan.dart
@@ -31,18 +31,6 @@ class WiFiScan {
     return errorCode == null ? null : _deserializeStartScanError(errorCode);
   }
 
-  Result<List<WiFiAccessPoint>, GetScannedResultsErrors>
-      _scannedResultMapToResult(Map map) {
-    // check if any error - return Result._error if any
-    final errorCode = map["error"];
-    if (errorCode != null) {
-      return Result._error(_deserializeGetScannedResultsError(errorCode));
-    }
-    // parse and return list of WiFiAccessPoint
-    return Result._value(List<WiFiAccessPoint>.unmodifiable(
-        map["value"].map((map) => WiFiAccessPoint._fromMap(map))));
-  }
-
   /// Get scanned access point.
   ///
   /// Returns [Result] object. If successful then [Result.value] is a [List] of
@@ -80,4 +68,16 @@ class WiFiScan {
             }
             throw UnsupportedError("Unknown event received: $event");
           });
+
+  Result<List<WiFiAccessPoint>, GetScannedResultsErrors>
+      _scannedResultMapToResult(Map map) {
+    // check if any error - return Result._error if any
+    final errorCode = map["error"];
+    if (errorCode != null) {
+      return Result._error(_deserializeGetScannedResultsError(errorCode));
+    }
+    // parse and return list of WiFiAccessPoint
+    return Result._value(List<WiFiAccessPoint>.unmodifiable(
+        map["value"].map((map) => WiFiAccessPoint._fromMap(map))));
+  }
 }

--- a/packages/wifi_scan/lib/wifi_scan.dart
+++ b/packages/wifi_scan/lib/wifi_scan.dart
@@ -3,8 +3,8 @@ import 'dart:async';
 import 'package:flutter/services.dart';
 
 part 'src/accesspoint.dart';
-
-part 'src/can.dart';
+part 'src/error.dart';
+part 'src/result.dart';
 
 /// The `wifi_scan` plugin entry point.
 ///
@@ -18,73 +18,66 @@ class WiFiScan {
   final _channel = const MethodChannel('wifi_scan');
   final _scannedResultsAvailableChannel =
       const EventChannel('wifi_scan/onScannedResultsAvailable');
-  Stream<List<WiFiAccessPoint>>? _onScannedResultsAvailable;
-
-  /// Checks if it is ok to invoke [startScan].
-  ///
-  /// Necesearry platform requirements, like permissions dependent services,
-  /// configuration, etc are checked.
-  ///
-  /// Set [askPermissions] flag to ask user for necessary permissions.
-  Future<CanStartScan> canStartScan({bool askPermissions = true}) async {
-    final canCode = await _channel.invokeMethod<int>("canStartScan", {
-      "askPermissions": askPermissions,
-    });
-    return _deserializeCanStartScan(canCode);
-  }
+  Stream<Result<List<WiFiAccessPoint>, GetScannedResultsErrors>>?
+      _onScannedResultsAvailable;
 
   /// Request a Wi-Fi scan.
   ///
-  /// Return value indicates if the "scan" trigger successed.
-  ///
-  /// Should call [canStartScan] as a check before calling this method.
-  Future<bool> startScan() async {
-    final isSucess = await _channel.invokeMethod<bool>("startScan");
-    return isSucess!;
-  }
-
-  /// Checks if it is ok to invoke [getScannedResults] or [onScannedResultsAvailable].
-  ///
-  /// Necesearry platform requirements, like permissions dependent services,
-  /// configuration, etc are checked.
-  ///
-  /// Set [askPermissions] flag to ask user for necessary permissions.
-  Future<CanGetScannedResults> canGetScannedResults(
-      {bool askPermissions = true}) async {
-    final canCode = await _channel.invokeMethod<int>("canGetScannedResults", {
+  /// Returns null if successful, else [StartScanErrors].
+  Future<StartScanErrors?> startScan({bool askPermissions = true}) async {
+    final errorCode = await _channel.invokeMethod<int>("startScan", {
       "askPermissions": askPermissions,
     });
-    return _deserializeCanGetScannedResults(canCode);
+    return errorCode == null ? null : _deserializeStartScanError(errorCode);
+  }
+
+  Result<List<WiFiAccessPoint>, GetScannedResultsErrors>
+      _scannedResultMapToResult(Map map) {
+    // check if any error - return Result._error if any
+    final errorCode = map["error"];
+    if (errorCode != null) {
+      return Result._error(_deserializeGetScannedResultsError(errorCode));
+    }
+    // parse and return list of WiFiAccessPoint
+    return Result._value(List<WiFiAccessPoint>.unmodifiable(
+        map["value"].map((map) => WiFiAccessPoint._fromMap(map))));
   }
 
   /// Get scanned access point.
   ///
-  /// This are cached accesss points from most recently performed scan.
+  /// Returns [Result] object. If successful then [Result.value] is a [List] of
+  /// [WiFiAccessPoint] and if failed then [Result.error] is a
+  /// [GetScannedResultsErrors] value.
   ///
-  /// Should call [canGetScannedResults] as a check before calling this method.
-  Future<List<WiFiAccessPoint>> getScannedResults() async {
-    final scannedResults =
-        await _channel.invokeListMethod<Map>("getScannedResults");
-    return scannedResults!
-        .map((map) => WiFiAccessPoint._fromMap(map))
-        .toList(growable: false);
+  /// [Result.value] are cached accesss points from most recently performed scan.
+  ///
+  /// Set [askPermissions] flag to ask user for necessary permissions.
+  Future<Result<List<WiFiAccessPoint>, GetScannedResultsErrors>>
+      getScannedResults({bool askPermissions = true}) async {
+    final resultMap = await _channel.invokeMapMethod("getScannedResults", {
+      "askPermissions": askPermissions,
+    });
+    return _scannedResultMapToResult(resultMap!);
   }
 
   /// Fires whenever new scanned results are available.
   ///
+  /// Each event is of type [Result], where [Result.value] is a [List] of
+  /// [WiFiAccessPoint] if fetched successfully or [Result.error] of type
+  /// [GetScannedResultsErrors] otherwise.
+  ///
+  /// Unlike [getScannedResults] required permission are never asked to the user.
+  ///
   /// New results are added to stream when platform performs the scan, either by
   /// itself or trigger with [startScan].
-  ///
-  /// Should call [canGetScannedResults] as a check before calling this method.
-  Stream<List<WiFiAccessPoint>> get onScannedResultsAvailable =>
-      _onScannedResultsAvailable ??=
-          _scannedResultsAvailableChannel.receiveBroadcastStream().map((event) {
-        if (event is Error) throw event;
-        if (event is List) {
-          return event
-              .map((map) => WiFiAccessPoint._fromMap(map))
-              .toList(growable: false);
-        }
-        return const <WiFiAccessPoint>[];
-      });
+  Stream<Result<List<WiFiAccessPoint>, GetScannedResultsErrors>>
+      get onScannedResultsAvailable =>
+          _onScannedResultsAvailable ??= _scannedResultsAvailableChannel
+              .receiveBroadcastStream()
+              .map((event) {
+            if (event is Map) {
+              return _scannedResultMapToResult(event);
+            }
+            throw UnsupportedError("Unknown event received: $event");
+          });
 }

--- a/packages/wifi_scan/test/wifi_scan_test.dart
+++ b/packages/wifi_scan/test/wifi_scan_test.dart
@@ -2,6 +2,12 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:wifi_scan/wifi_scan.dart';
 
+Map _makeResult({dynamic value, dynamic error}) {
+  assert((value != null) ^ (error != null));
+  if (error != null) return {"error": error};
+  return {"value": value};
+}
+
 void main() {
   const channel = MethodChannel('wifi_scan');
   final mockHandlers = <String, Function(dynamic arguments)>{};
@@ -22,80 +28,92 @@ void main() {
     channel.setMockMethodCallHandler(null);
   });
 
-  test('canStartScan', () async {
-    final canCodes = [0, 1, 2, 3, 4, 5];
-    final enumValues = [
-      CanStartScan.notSupported,
-      CanStartScan.yes,
-      CanStartScan.noLocationPermissionRequired,
-      CanStartScan.noLocationPermissionDenied,
-      CanStartScan.noLocationPermissionUpgradeAccuracy,
-      CanStartScan.noLocationServiceDisabled,
-    ];
-    for (int i = 0; i < canCodes.length; i++) {
-      mockHandlers["canStartScan"] = (_) => canCodes[i];
-      expect(await WiFiScan.instance.canStartScan(), enumValues[i]);
-    }
+  group("startScan", () {
+    test('successful', () async {
+      mockHandlers["startScan"] = (_) => null;
+      expect(await WiFiScan.instance.startScan(), isNull);
+    });
 
-    // -ve test
-    final badCanCodes = [null, -1, 6, 7];
-    for (int i = 0; i < badCanCodes.length; i++) {
-      mockHandlers["canStartScan"] = (_) => badCanCodes[i];
-      expect(() async => await WiFiScan.instance.canStartScan(),
-          throwsUnsupportedError);
-    }
+    test("fail with valid code", () async {
+      final errorCodes = [0, 1, 2, 3, 4, 5];
+      final enumValues = [
+        StartScanErrors.notSupported,
+        StartScanErrors.noLocationPermissionRequired,
+        StartScanErrors.noLocationPermissionDenied,
+        StartScanErrors.noLocationPermissionUpgradeAccuracy,
+        StartScanErrors.noLocationServiceDisabled,
+        StartScanErrors.failed,
+      ];
+      for (int i = 0; i < errorCodes.length; i++) {
+        mockHandlers["startScan"] = (_) => errorCodes[i];
+        expect(await WiFiScan.instance.startScan(), enumValues[i]);
+      }
+    });
+
+    test("fail with in valid code", () {
+      final badErrorCodes = [-1, 6, 7];
+      for (var erroCode in badErrorCodes) {
+        mockHandlers["startScan"] = (_) => erroCode;
+        expect(() async => await WiFiScan.instance.startScan(),
+            throwsUnsupportedError);
+      }
+    });
   });
 
-  test('startScan', () async {
-    mockHandlers["startScan"] = (_) => true;
-    expect(await WiFiScan.instance.startScan(), true);
-  });
+  group("getScannedResults", () {
+    test("successfull", () async {
+      mockHandlers["getScannedResults"] = (_) => _makeResult(value: [
+            {
+              "ssid": "my-ssid",
+              "bssid": "00:00:00:12",
+              "capabilities": "Unknown",
+              "frequency": 600,
+              "level": 5,
+              "timestamp": null,
+              "standard": null,
+              "centerFrequency0": null,
+              "centerFrequency1": null,
+              "channelWidth": null,
+              "isPasspoint": null,
+              "operatorFriendlyName": null,
+              "venueName": null,
+              "is80211mcResponder": null,
+            }
+          ]);
+      final result = await WiFiScan.instance.getScannedResults();
+      expect(result.hasError, false);
+      expect(result.value, isNotNull);
+      expect(result.value!.length, 1);
+    });
 
-  test("CanGetScannedResults", () async {
-    final canCodes = [0, 1, 2, 3, 4, 5];
-    final enumValues = [
-      CanGetScannedResults.notSupported,
-      CanGetScannedResults.yes,
-      CanGetScannedResults.noLocationPermissionRequired,
-      CanGetScannedResults.noLocationPermissionDenied,
-      CanGetScannedResults.noLocationPermissionUpgradeAccuracy,
-      CanGetScannedResults.noLocationServiceDisabled,
-    ];
-    for (int i = 0; i < canCodes.length; i++) {
-      mockHandlers["canGetScannedResults"] = (_) => canCodes[i];
-      expect(await WiFiScan.instance.canGetScannedResults(), enumValues[i]);
-    }
+    test("fail with valid code", () async {
+      final errorCodes = [0, 1, 2, 3, 4];
+      final enumValues = [
+        GetScannedResultsErrors.notSupported,
+        GetScannedResultsErrors.noLocationPermissionRequired,
+        GetScannedResultsErrors.noLocationPermissionDenied,
+        GetScannedResultsErrors.noLocationPermissionUpgradeAccuracy,
+        GetScannedResultsErrors.noLocationServiceDisabled,
+      ];
+      for (int i = 0; i < errorCodes.length; i++) {
+        mockHandlers["getScannedResults"] =
+            (_) => _makeResult(error: errorCodes[i]);
+        final result = await WiFiScan.instance.getScannedResults();
+        expect(result.hasError, true);
+        expect(result.error, isNotNull);
+        expect(result.error, enumValues[i]);
+      }
+    });
 
-    // -ve test
-    final badCanCodes = [null, -1, 6, 7];
-    for (int i = 0; i < badCanCodes.length; i++) {
-      mockHandlers["canGetScannedResults"] = (_) => badCanCodes[i];
-      expect(() async => await WiFiScan.instance.canGetScannedResults(),
-          throwsUnsupportedError);
-    }
-  });
-
-  test("getScannedResults", () async {
-    mockHandlers["getScannedResults"] = (_) => [
-          {
-            "ssid": "my-ssid",
-            "bssid": "00:00:00:12",
-            "capabilities": "Unknown",
-            "frequency": 600,
-            "level": 5,
-            "timestamp": null,
-            "standard": null,
-            "centerFrequency0": null,
-            "centerFrequency1": null,
-            "channelWidth": null,
-            "isPasspoint": null,
-            "operatorFriendlyName": null,
-            "venueName": null,
-            "is80211mcResponder": null,
-          }
-        ];
-    final scannedNetworks = await WiFiScan.instance.getScannedResults();
-    expect(scannedNetworks.length, 1);
+    test("fail with invalid code", () async {
+      final badCanCodes = [-1, 6, 7];
+      for (int i = 0; i < badCanCodes.length; i++) {
+        mockHandlers["getScannedResults"] =
+            (_) => _makeResult(error: badCanCodes[i]);
+        expect(() async => await WiFiScan.instance.getScannedResults(),
+            throwsUnsupportedError);
+      }
+    });
   });
 
   // TODO: firgure out way to mock EventChannel


### PR DESCRIPTION
 - instead `Result<ValueType, ErrorType>` is added and used as return type
 - example app simplified
 - Kotlin upgrade