### PR TITLE
docs(wifi_iot): deprecating message for "scan" related APIs

### DIFF
--- a/packages/wifi_iot/README.md
+++ b/packages/wifi_iot/README.md
@@ -23,7 +23,7 @@ Becareful, some commands as no effect on iOS because Apple don't let us to do wh
 | :---------------------------------------------------- | :----------------: | :------------------: |
 | Enabling / Disabling WiFi module                      | :warning:(3a) |  :x:  |
 | Getting WiFi status                                   | :white_check_mark: |  :x:  |
-| Scanning for networks, with "already-associated" flag | :white_check_mark: |  :x:  |
+| Scanning for networks, with "already-associated" flag | :white_check_mark:(4) |  :x:  |
 | Connecting / Disconnecting on a network in WPA / WEP  | :white_check_mark:(3b) |  :white_check_mark:(1)  |
 | Registering / Unregistering a WiFi network            | :white_check_mark:(3c) |  :warning:(2)  |
 | Getting informations like :                           | :white_check_mark: |  :white_check_mark:  |
@@ -45,6 +45,8 @@ Becareful, some commands as no effect on iOS because Apple don't let us to do wh
     * (iii) To connect to network with internet use `withInternet` which is a different API underneath (this API will not disconnect to network after app closes, therefore use `removeWifiNetwork` method to remove/disconnect network added in previous session) [[docs](https://developer.android.com/guide/topics/connectivity/wifi-suggest)].
     * (iv) Will have to use `forceWifiUsage(true)` to route app traffic via connected access point, similarly can be disabled to route traffic via cellular network (for internet). This is not enabled by default and left upto to the user. 
   * c. Registering Wifi Network, will require user approval - and the network saved would not be controlled by the app (for deletion, updation, etc) [[docs](https://developer.android.com/guide/topics/connectivity/wifi-save-network-passpoint-config)];
+
+:warning:(4): This functionality is "discontinued" - checkout [`wifi_scan`](https://pub.dev/packages/wifi_scan) plugin instead.
 
 Additional Wifi protocols on Android side like - Wifi Direct, Wifi Aware, etc are in active discussion at [#140](https://github.com/flutternetwork/WiFiFlutter/issues/140). Encourage you to engage if you want this features.
 

--- a/packages/wifi_iot/README.md
+++ b/packages/wifi_iot/README.md
@@ -46,7 +46,7 @@ Becareful, some commands as no effect on iOS because Apple don't let us to do wh
     * (iv) Will have to use `forceWifiUsage(true)` to route app traffic via connected access point, similarly can be disabled to route traffic via cellular network (for internet). This is not enabled by default and left upto to the user. 
   * c. Registering Wifi Network, will require user approval - and the network saved would not be controlled by the app (for deletion, updation, etc) [[docs](https://developer.android.com/guide/topics/connectivity/wifi-save-network-passpoint-config)];
 
-:warning:(4): This functionality is "discontinued" - checkout [`wifi_scan`](https://pub.dev/packages/wifi_scan) plugin instead.
+:warning:(4): This functionality is "discontinued" - checkout new [`wifi_scan`](https://pub.dev/packages/wifi_scan) plugin (also by WiFiFlutter) instead.
 
 Additional Wifi protocols on Android side like - Wifi Direct, Wifi Aware, etc are in active discussion at [#140](https://github.com/flutternetwork/WiFiFlutter/issues/140). Encourage you to engage if you want this features.
 

--- a/packages/wifi_iot/lib/wifi_iot.dart
+++ b/packages/wifi_iot/lib/wifi_iot.dart
@@ -196,6 +196,8 @@ class WiFiForIoTPlugin {
 
   static Stream<List<WifiNetwork>>? _onWifiScanResultReady;
 
+  @Deprecated("APIs related to 'scan' functionalities are deprecated. "
+      "Switch to `wifi_scan` plugin - https://pub.dev/packages/wifi_scan")
   static Stream<List<WifiNetwork>> get onWifiScanResultReady {
     if (_onWifiScanResultReady == null) {
       _onWifiScanResultReady = _eventChannel
@@ -218,6 +220,8 @@ class WiFiForIoTPlugin {
     return htResult;
   }
 
+  @Deprecated("APIs related to 'scan' functionalities are deprecated. "
+      "Switch to `wifi_scan` plugin - https://pub.dev/packages/wifi_scan")
   static Future<List<WifiNetwork>> loadWifiList() async {
     final List<WifiNetwork> result = (await _loadWifiList() ?? <WifiNetwork>[]);
     if (result.length >= 1) return result;
@@ -614,6 +618,8 @@ class APClient {
   }
 }
 
+@Deprecated("APIs related to 'scan' functionalities are deprecated. "
+    "Switch to `wifi_scan` plugin - https://pub.dev/packages/wifi_scan")
 class WifiNetwork {
   String? ssid;
   String? bssid;

--- a/packages/wifi_iot/lib/wifi_iot.dart
+++ b/packages/wifi_iot/lib/wifi_iot.dart
@@ -23,8 +23,8 @@ const serializeNetworkSecurityMap = <NetworkSecurity, String>{
 
 const MethodChannel _channel = const MethodChannel('wifi_iot');
 @Deprecated(
-    "APIs related to 'scan' functionalities are deprecated in `wifi_iot`. "
-    "Switch to new `wifi_scan` plugin by WiFiFlutter - https://pub.dev/packages/wifi_scan")
+    "This is discontinued, switch to new `wifi_scan` plugin by WiFiFlutter. "
+    "Check - https://pub.dev/packages/wifi_scan")
 const EventChannel _eventChannel =
     const EventChannel('plugins.wififlutter.io/wifi_scan');
 
@@ -198,13 +198,13 @@ class WiFiForIoTPlugin {
   }
 
   @Deprecated(
-      "APIs related to 'scan' functionalities are deprecated in `wifi_iot`. "
-      "Switch to new `wifi_scan` plugin by WiFiFlutter - https://pub.dev/packages/wifi_scan")
+      "This is discontinued, switch to new `wifi_scan` plugin by WiFiFlutter. "
+      "Check - https://pub.dev/packages/wifi_scan")
   static Stream<List<WifiNetwork>>? _onWifiScanResultReady;
 
   @Deprecated(
-      "APIs related to 'scan' functionalities are deprecated in `wifi_iot`. "
-      "Switch to new `wifi_scan` plugin by WiFiFlutter - https://pub.dev/packages/wifi_scan")
+      "This is discontinued, switch to new `wifi_scan` plugin by WiFiFlutter. "
+      "Check - https://pub.dev/packages/wifi_scan")
   static Stream<List<WifiNetwork>> get onWifiScanResultReady {
     if (_onWifiScanResultReady == null) {
       _onWifiScanResultReady = _eventChannel
@@ -215,8 +215,8 @@ class WiFiForIoTPlugin {
   }
 
   @Deprecated(
-      "APIs related to 'scan' functionalities are deprecated in `wifi_iot`. "
-      "Switch to new `wifi_scan` plugin by WiFiFlutter - https://pub.dev/packages/wifi_scan")
+      "This is discontinued, switch to new `wifi_scan` plugin by WiFiFlutter. "
+      "Check - https://pub.dev/packages/wifi_scan")
   static Future<List<WifiNetwork>>? _loadWifiList() async {
     final Map<String, String> htArguments = Map();
     String? sResult;
@@ -231,8 +231,8 @@ class WiFiForIoTPlugin {
   }
 
   @Deprecated(
-      "APIs related to 'scan' functionalities are deprecated in `wifi_iot`. "
-      "Switch to new `wifi_scan` plugin by WiFiFlutter - https://pub.dev/packages/wifi_scan")
+      "This is discontinued, switch to new `wifi_scan` plugin by WiFiFlutter. "
+      "Check - https://pub.dev/packages/wifi_scan")
   static Future<List<WifiNetwork>> loadWifiList() async {
     final List<WifiNetwork> result = (await _loadWifiList() ?? <WifiNetwork>[]);
     if (result.length >= 1) return result;
@@ -633,8 +633,8 @@ class APClient {
 }
 
 @Deprecated(
-    "APIs related to 'scan' functionalities are deprecated in `wifi_iot`. "
-    "Switch to new `wifi_scan` plugin by WiFiFlutter - https://pub.dev/packages/wifi_scan")
+    "This is discontinued, switch to new `wifi_scan` plugin by WiFiFlutter. "
+    "Check - https://pub.dev/packages/wifi_scan")
 class WifiNetwork {
   String? ssid;
   String? bssid;

--- a/packages/wifi_iot/lib/wifi_iot.dart
+++ b/packages/wifi_iot/lib/wifi_iot.dart
@@ -22,6 +22,9 @@ const serializeNetworkSecurityMap = <NetworkSecurity, String>{
 };
 
 const MethodChannel _channel = const MethodChannel('wifi_iot');
+@Deprecated(
+    "APIs related to 'scan' functionalities are deprecated in `wifi_iot`. "
+    "Switch to new `wifi_scan` plugin by WiFiFlutter - https://pub.dev/packages/wifi_scan")
 const EventChannel _eventChannel =
     const EventChannel('plugins.wififlutter.io/wifi_scan');
 

--- a/packages/wifi_iot/lib/wifi_iot.dart
+++ b/packages/wifi_iot/lib/wifi_iot.dart
@@ -194,6 +194,9 @@ class WiFiForIoTPlugin {
     }
   }
 
+  @Deprecated(
+      "APIs related to 'scan' functionalities are deprecated in `wifi_iot`. "
+      "Switch to new `wifi_scan` plugin by WiFiFlutter - https://pub.dev/packages/wifi_scan")
   static Stream<List<WifiNetwork>>? _onWifiScanResultReady;
 
   @Deprecated(

--- a/packages/wifi_iot/lib/wifi_iot.dart
+++ b/packages/wifi_iot/lib/wifi_iot.dart
@@ -196,8 +196,9 @@ class WiFiForIoTPlugin {
 
   static Stream<List<WifiNetwork>>? _onWifiScanResultReady;
 
-  @Deprecated("APIs related to 'scan' functionalities are deprecated. "
-      "Switch to `wifi_scan` plugin - https://pub.dev/packages/wifi_scan")
+  @Deprecated(
+      "APIs related to 'scan' functionalities are deprecated in `wifi_iot`. "
+      "Switch to new `wifi_scan` plugin by WiFiFlutter - https://pub.dev/packages/wifi_scan")
   static Stream<List<WifiNetwork>> get onWifiScanResultReady {
     if (_onWifiScanResultReady == null) {
       _onWifiScanResultReady = _eventChannel
@@ -207,6 +208,9 @@ class WiFiForIoTPlugin {
     return _onWifiScanResultReady!;
   }
 
+  @Deprecated(
+      "APIs related to 'scan' functionalities are deprecated in `wifi_iot`. "
+      "Switch to new `wifi_scan` plugin by WiFiFlutter - https://pub.dev/packages/wifi_scan")
   static Future<List<WifiNetwork>>? _loadWifiList() async {
     final Map<String, String> htArguments = Map();
     String? sResult;
@@ -220,8 +224,9 @@ class WiFiForIoTPlugin {
     return htResult;
   }
 
-  @Deprecated("APIs related to 'scan' functionalities are deprecated. "
-      "Switch to `wifi_scan` plugin - https://pub.dev/packages/wifi_scan")
+  @Deprecated(
+      "APIs related to 'scan' functionalities are deprecated in `wifi_iot`. "
+      "Switch to new `wifi_scan` plugin by WiFiFlutter - https://pub.dev/packages/wifi_scan")
   static Future<List<WifiNetwork>> loadWifiList() async {
     final List<WifiNetwork> result = (await _loadWifiList() ?? <WifiNetwork>[]);
     if (result.length >= 1) return result;
@@ -618,8 +623,9 @@ class APClient {
   }
 }
 
-@Deprecated("APIs related to 'scan' functionalities are deprecated. "
-    "Switch to `wifi_scan` plugin - https://pub.dev/packages/wifi_scan")
+@Deprecated(
+    "APIs related to 'scan' functionalities are deprecated in `wifi_iot`. "
+    "Switch to new `wifi_scan` plugin by WiFiFlutter - https://pub.dev/packages/wifi_scan")
 class WifiNetwork {
   String? ssid;
   String? bssid;

--- a/packages/wifi_iot/lib/wifi_iot.dart
+++ b/packages/wifi_iot/lib/wifi_iot.dart
@@ -289,6 +289,7 @@ class WiFiForIoTPlugin {
   ///
   /// @param [bssid] The BSSID (unique id) of the network to connect to.
   ///   This allows to specify exactly which network to connect to.
+  // ignore: deprecated_member_use_from_same_package
   ///   To obtain the BSSID, use [loadWifiList] (Android only) or save the value
   ///   from a previous connection.
   ///   On Android, specifying the BSSID will also result in no system message
@@ -360,6 +361,7 @@ class WiFiForIoTPlugin {
   /// @param [bssid] The BSSID (unique id) of the network to register.
   ///   This allows to specify exactly which network to register in case of
   ///   duplicated SSID.
+  // ignore: deprecated_member_use_from_same_package
   ///   To obtain the BSSID, use [loadWifiList] (Android only) or save the value
   ///   from a previous connection.
   ///   On Android, specifying the BSSID will also result in no system message
@@ -424,6 +426,7 @@ class WiFiForIoTPlugin {
   ///
   /// @param [bssid] The BSSID (unique id) of the network to connect to.
   ///   This allows to specify exactly which network to connect to.
+  // ignore: deprecated_member_use_from_same_package
   ///   To obtain the BSSID, use [loadWifiList] (Android only) or save the value
   ///   from a previous connection.
   ///   On Android, specifying the BSSID will also result in no system message


### PR DESCRIPTION
  - nudging to switch to `wifi_scan`