### PR TITLE
fix(wifi_iot): Fix connection to registered network on Android < 10 (Q)

### DIFF
--- a/packages/wifi_iot/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
+++ b/packages/wifi_iot/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
@@ -1354,7 +1354,7 @@ public class WifiIotPlugin
     }
 
     // Try returning last known valid network id
-    if(updateNetwork == -1) {
+    if (updateNetwork == -1) {
       return registeredNetwork;
     }
 

--- a/packages/wifi_iot/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
+++ b/packages/wifi_iot/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
@@ -13,6 +13,7 @@ import android.net.Network;
 import android.net.NetworkCapabilities;
 import android.net.NetworkRequest;
 import android.net.wifi.ScanResult;
+import android.net.wifi.SupplicantState;
 import android.net.wifi.WifiConfiguration;
 import android.net.wifi.WifiInfo;
 import android.net.wifi.WifiManager;
@@ -1328,6 +1329,7 @@ public class WifiIotPlugin
   @SuppressWarnings("deprecation")
   private int registerWifiNetworkDeprecated(android.net.wifi.WifiConfiguration conf) {
     int updateNetwork = -1;
+    int registeredNetwork = -1;
 
     /// Remove the existing configuration for this netwrok
     List<android.net.wifi.WifiConfiguration> mWifiConfigList = moWiFi.getConfiguredNetworks();
@@ -1339,6 +1341,7 @@ public class WifiIotPlugin
                 || conf.BSSID == null
                 || wifiConfig.BSSID.equals(conf.BSSID))) {
           conf.networkId = wifiConfig.networkId;
+          registeredNetwork = wifiConfig.networkId;
           updateNetwork = moWiFi.updateNetwork(conf);
         }
       }
@@ -1348,6 +1351,11 @@ public class WifiIotPlugin
     if (updateNetwork == -1) {
       updateNetwork = moWiFi.addNetwork(conf);
       moWiFi.saveConfiguration();
+    }
+
+    // Try returning last known valid network id
+    if(updateNetwork == -1) {
+      return registeredNetwork;
     }
 
     return updateNetwork;
@@ -1430,14 +1438,19 @@ public class WifiIotPlugin
     if (!enabled) return false;
 
     boolean connected = false;
-    for (int i = 0; i < 30; i++) {
-      int networkId = moWiFi.getConnectionInfo().getNetworkId();
-      if (networkId != -1) {
+    for (int i = 0; i < 20; i++) {
+      WifiInfo currentNet = moWiFi.getConnectionInfo();
+      int networkId = currentNet.getNetworkId();
+      SupplicantState netState = currentNet.getSupplicantState();
+
+      // Wait for connection to reach state completed
+      // to discard false positives like auth error
+      if (networkId != -1 && netState == SupplicantState.COMPLETED) {
         connected = networkId == updateNetwork;
         break;
       }
       try {
-        Thread.sleep(1000);
+        Thread.sleep(500);
       } catch (InterruptedException ignored) {
         break;
       }


### PR DESCRIPTION
This is my proposed fix for issue #275

Changed the method `registerWifiNetworkDeprecated` to save found network id.  It it fails to both UPDATE or ADD a network it will return the registered network's id or fallback to -1;

This alone solved the issue of connecting to an already registered network. However during normal usage, if you tried to connect to a network using the wrong password, it would connect to it anyway, only to disconect with "Invalid Credentials" message in a few seconds.

In order to verify that the connection is actually taking place I changed the loop to watch for the [SupplicantState](https://developer.android.com/reference/android/net/wifi/SupplicantState) of the connection, and only break when some connection reaches "COMPLETED" status. 

Since this new check could lead to waiting the full loop time if no connection is done, I lowered the sleep time to 500 and iterations count to 20, to a maximum of ~10secs wait in the worst case.

I hope this can solve the problem for everyone having the same problem