### PR TITLE
fix(wifi_iot): Add support for SDK-31 concurrent networks addresses #273

### DIFF
--- a/packages/wifi_iot/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
+++ b/packages/wifi_iot/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
@@ -1229,7 +1229,7 @@ public class WifiIotPlugin
     // remove network suggestion
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
       List<WifiNetworkSuggestion> suggestions = moWiFi.getNetworkSuggestions();
-      List<WifiNetworkSuggestion> removeSuggestions = new ArrayList();
+      List<WifiNetworkSuggestion> removeSuggestions = new ArrayList<WifiNetworkSuggestion>();
       for (int i = 0, suggestionsSize = suggestions.size(); i < suggestionsSize; i++) {
         WifiNetworkSuggestion suggestion = suggestions.get(i);
         if (suggestion.getSsid().startsWith(prefix_ssid)) {


### PR DESCRIPTION
This PR addresses #273 

Post SDK-31 (Android 11) the operating system supports concurrent connections. To address this Marichou created a fork of this repository and put a fix in place.

I've tidied the solution up and tested it against a Pixel 2 XL, Pixel 6a, and a Galaxy Tab A7 lite, and the solution works on all devices.

Also fixed a uses unchecked or unsafe operations warning.