### PR TITLE
fix: multiple triggering issue of NetworkCallback on Android 10

### DIFF
--- a/packages/wifi_iot/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
+++ b/packages/wifi_iot/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
@@ -1418,9 +1418,20 @@ public class WifiIotPlugin
               @Override
               public void onUnavailable() {
                 super.onUnavailable();
+                if (Build.VERSION.SDK_INT == Build.VERSION_CODES.Q) {
+                  connectivityManager.unregisterNetworkCallback(this);
+                }
                 if (!resultSent) {
                   poResult.success(false);
                   resultSent = true;
+                }
+              }
+
+              @Override
+              public void onLost(Network network) {
+                super.onLost(network);
+                if (Build.VERSION.SDK_INT == Build.VERSION_CODES.Q) {
+                  connectivityManager.unregisterNetworkCallback(this);
                 }
               }
             };


### PR DESCRIPTION
In Android 10, there is an issue where connection failures lead to repeated attempts to reconnect, resulting in the NetworkCallback being continuously triggered. However, within the context of Flutter, the FlutterResult allows only one return. To address this problem, it is recommended to unregister the NetworkCallback upon the first occurrence of the onUnavailable or onLost event, preventing subsequent redundant invocations. This pull request aims to implement this solution.