### PR TITLE
fix(wifi_iot): iOS isConnected always true even connection is failed

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -568,6 +568,24 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "Bojan227",
+      "name": "Bojan Blazevski",
+      "avatar_url": "https://avatars.githubusercontent.com/u/80133862?v=4",
+      "profile": "https://github.com/Bojan227",
+      "contributions": [
+        "bug"
+      ]
+    },
+    {
+      "login": "UnluckyY1",
+      "name": "Yassine Ben Massaoud",
+      "avatar_url": "https://avatars.githubusercontent.com/u/48437666?v=4",
+      "profile": "https://github.com/UnluckyY1",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/.github/workflows/all_plugins.yaml
+++ b/.github/workflows/all_plugins.yaml
@@ -2,6 +2,8 @@ name: all_plugins
 
 on:
   pull_request:
+    branches:
+      - master
     paths-ignore:
       - "docs/**"
       - "website/**"

--- a/.github/workflows/wifi_iot.yaml
+++ b/.github/workflows/wifi_iot.yaml
@@ -3,6 +3,8 @@ name: wifi_iot
 
 on:
   pull_request:
+    branches:
+      - master
     paths:
       - "packages/wifi_iot/**"
       - ".github/workflows/wifi_iot.yaml"

--- a/.github/workflows/wifi_scan.yaml
+++ b/.github/workflows/wifi_scan.yaml
@@ -3,6 +3,8 @@ name: wifi_scan
 
 on:
   pull_request:
+    branches:
+      - master
     paths:
       - "packages/wifi_scan/**"
       - ".github/workflows/wifi_scan.yaml"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2024-08-27
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`wifi_iot` - `v0.3.19+1`](#wifi_iot---v03191)
+ - [`wifi_scan` - `v0.4.1+1`](#wifi_scan---v0411)
+
+---
+
+#### `wifi_iot` - `v0.3.19+1`
+
+ - **FIX**: Update compileSdkVersion to fix Android release build with flutter 3.24 (#398).
+
+#### `wifi_scan` - `v0.4.1+1`
+
+ - **FIX**: Update compileSdkVersion to fix Android release build with flutter 3.24 (#398).
+
+
 ## 2023-09-04
 
 ### Changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 <a href="https://github.com/flutternetwork/WiFiFlutter/actions?query=workflow%3Aall_plugins">
     <img src="https://github.com/flutternetwork/WiFiFlutter/workflows/all_plugins/badge.svg" alt="all_plugins GitHub Workflow Status"/>
 </a><!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-<a href="https://github.com/flutternetwork/WiFiFlutter/blob/master/CONTRIBUTORS.md#contributors-"><img src="https://img.shields.io/badge/all_contributors-56-orange.svg" alt="All Contributors" /></a>
+<a href="https://github.com/flutternetwork/WiFiFlutter/blob/master/CONTRIBUTORS.md#contributors-"><img src="https://img.shields.io/badge/all_contributors-58-orange.svg" alt="All Contributors" /></a>
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,5 +1,5 @@
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-<a href="https://github.com/flutternetwork/WiFiFlutter/blob/master/CONTRIBUTORS.md#contributors-"><img src="https://img.shields.io/badge/all_contributors-56-orange.svg" alt="All Contributors" /></a>
+<a href="https://github.com/flutternetwork/WiFiFlutter/blob/master/CONTRIBUTORS.md#contributors-"><img src="https://img.shields.io/badge/all_contributors-58-orange.svg" alt="All Contributors" /></a>
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 ## Contributors ✨
@@ -80,6 +80,8 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <tr>
       <td align="center" valign="top" width="11.11%"><a href="https://github.com/weitsai"><img src="https://avatars.githubusercontent.com/u/1283491?v=4?s=100" width="100px;" alt="蔡佳緯"/><br /><sub><b>蔡佳緯</b></sub></a><br /><a href="https://github.com/flutternetwork/WiFiFlutter/commits?author=weitsai" title="Code">💻</a></td>
       <td align="center" valign="top" width="11.11%"><a href="https://github.com/thearaks"><img src="https://avatars.githubusercontent.com/u/5188791?v=4?s=100" width="100px;" alt="Mattia Aracne"/><br /><sub><b>Mattia Aracne</b></sub></a><br /><a href="https://github.com/flutternetwork/WiFiFlutter/commits?author=thearaks" title="Code">💻</a></td>
+      <td align="center" valign="top" width="11.11%"><a href="https://github.com/Bojan227"><img src="https://avatars.githubusercontent.com/u/80133862?v=4?s=100" width="100px;" alt="Bojan Blazevski"/><br /><sub><b>Bojan Blazevski</b></sub></a><br /><a href="https://github.com/flutternetwork/WiFiFlutter/issues?q=author%3ABojan227" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="11.11%"><a href="https://github.com/UnluckyY1"><img src="https://avatars.githubusercontent.com/u/48437666?v=4?s=100" width="100px;" alt="Yassine Ben Massaoud"/><br /><sub><b>Yassine Ben Massaoud</b></sub></a><br /><a href="https://github.com/flutternetwork/WiFiFlutter/commits?author=UnluckyY1" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a href="https://codecov.io/gh/flutternetwork/WiFiFlutter/">
     <img src="https://codecov.io/gh/flutternetwork/WiFiFlutter/graph/badge.svg" alt="all_plugins Coverage"/>
   </a><!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-<a href="https://github.com/flutternetwork/WiFiFlutter/blob/master/CONTRIBUTORS.md#contributors-"><img src="https://img.shields.io/badge/all_contributors-56-orange.svg" alt="All Contributors" /></a>
+<a href="https://github.com/flutternetwork/WiFiFlutter/blob/master/CONTRIBUTORS.md#contributors-"><img src="https://img.shields.io/badge/all_contributors-58-orange.svg" alt="All Contributors" /></a>
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
   <a href="https://gitter.im/flutternetwork/WiFiFlutter?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge">
     <img src="https://badges.gitter.im/flutternetwork/WiFiFlutter.svg" alt="Join the chat at https://gitter.im/flutternetwork/WiFiFlutter]">

--- a/packages/wifi_iot/CHANGELOG.md
+++ b/packages/wifi_iot/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.19+1
+
+ - **FIX**: Update compileSdkVersion to fix Android release build with flutter 3.24 (#398).
+
 ## 0.3.19
 
  - **CHORE**: Update Gradle to 8.2 and AGP to 8.2.0 (#360)

--- a/packages/wifi_iot/android/build.gradle
+++ b/packages/wifi_iot/android/build.gradle
@@ -24,7 +24,7 @@ apply plugin: 'com.android.library'
 android {
     namespace 'com.alternadom.wifiiot'
 
-    compileSdkVersion 30
+    compileSdkVersion 34
 
     defaultConfig {
         minSdkVersion 16

--- a/packages/wifi_iot/ios/Classes/SwiftWifiIotPlugin.swift
+++ b/packages/wifi_iot/ios/Classes/SwiftWifiIotPlugin.swift
@@ -124,14 +124,7 @@ public class SwiftWifiIotPlugin: NSObject, FlutterPlugin {
         let sPassword = (call.arguments as? [String : AnyObject])?["password"] as? String? ?? nil
         let bJoinOnce = (call.arguments as? [String : AnyObject])?["join_once"] as! Bool?
         let sSecurity = (call.arguments as? [String : AnyObject])?["security"] as! String?
-        
-        //        print("SSID : '\(sSSID)'")
-        //        print("PASSWORD : '\(sPassword)'")
-        //        print("JOIN_ONCE : '\(bJoinOnce)'")
-        //        if (bJoinOnce) {
-        //            print("The network will be forgotten!")
-        //        }
-        //        print("SECURITY : '\(sSecurity)'")
+
         if #available(iOS 11.0, *) {
             let configuration = initHotspotConfiguration(ssid: sSSID, passphrase: sPassword, security: sSecurity)
             configuration.joinOnce = bJoinOnce ?? false
@@ -142,19 +135,19 @@ public class SwiftWifiIotPlugin: NSObject, FlutterPlugin {
                     result(false)
                     return
                 }
-                this.getSSID { (sSSID) -> () in
+                this.getSSID { (connectedSSID) -> () in
                     if (error != nil) {
                         if (error?.localizedDescription == "already associated.") {
-                            print("Connected to '\(sSSID ?? "<Unknown Network>")'")
+                            print("Connected to '\(connectedSSID ?? "<Unknown Network>")'")
                             result(true)
                         } else {
                             print("Not Connected")
                             result(false)
                         }
-                    } else if let ssid = sSSID {
-                        print("Connected to " + ssid)
-                        // ssid check is required because if wifi not found (could not connect) there seems to be no error given
-                        result(ssid == sSSID)
+                    } else if let connectedSSID = connectedSSID {
+                        print("Connected to " + connectedSSID)
+                        // Emit result of [isConnected] by checking if targetSSID is the same as connectedSSID.
+                        result(sSSID == connectedSSID)
                     } else {
                         print("WiFi network not found")
                         result(false)

--- a/packages/wifi_iot/pubspec.yaml
+++ b/packages/wifi_iot/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wifi_iot
 description: Flutter plugin which can handle WiFi connections and hotspot (AP, STA)
-version: 0.3.19
+version: 0.3.19+1
 homepage: https://github.com/flutternetwork/WiFiFlutter/tree/master/packages/wifi_iot
 
 flutter:

--- a/packages/wifi_scan/CHANGELOG.md
+++ b/packages/wifi_scan/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1+1
+
+ - **FIX**: Update compileSdkVersion to fix Android release build with flutter 3.24 (#398).
+
 ## 0.4.1
 - 
 - **CHORE**: Update Gradle to 8.2 and AGP to 8.2.0 (#360)

--- a/packages/wifi_scan/android/build.gradle
+++ b/packages/wifi_scan/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: 'kotlin-android'
 android {
     namespace 'dev.flutternetwork.wifi.wifi_scan'
 
-    compileSdkVersion 30
+    compileSdkVersion 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/packages/wifi_scan/example/lib/main.dart
+++ b/packages/wifi_scan/example/lib/main.dart
@@ -31,14 +31,14 @@ class _MyAppState extends State<MyApp> {
       final can = await WiFiScan.instance.canStartScan();
       // if can-not, then show error
       if (can != CanStartScan.yes) {
-        if (mounted) kShowSnackBar(context, "Cannot start scan: $can");
+        if (context.mounted) kShowSnackBar(context, "Cannot start scan: $can");
         return;
       }
     }
 
     // call startScan API
     final result = await WiFiScan.instance.startScan();
-    if (mounted) kShowSnackBar(context, "startScan: $result");
+    if (context.mounted) kShowSnackBar(context, "startScan: $result");
     // reset access points.
     setState(() => accessPoints = <WiFiAccessPoint>[]);
   }
@@ -49,7 +49,9 @@ class _MyAppState extends State<MyApp> {
       final can = await WiFiScan.instance.canGetScannedResults();
       // if can-not, then show error
       if (can != CanGetScannedResults.yes) {
-        if (mounted) kShowSnackBar(context, "Cannot get scanned results: $can");
+        if (context.mounted) {
+          kShowSnackBar(context, "Cannot get scanned results: $can");
+        }
         accessPoints = <WiFiAccessPoint>[];
         return false;
       }

--- a/packages/wifi_scan/pubspec.yaml
+++ b/packages/wifi_scan/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wifi_scan
 description: Flutter plugin to scan for nearby visible WiFi access points.
-version: 0.4.1
+version: 0.4.1+1
 homepage: https://github.com/flutternetwork/WiFiFlutter/tree/master/packages/wifi_scan
 
 environment:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: args
-      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
+      sha256: "7cf60b9f0cc88203c5a190b4cd62a99feea42759a7fa695010eb5de1c0b2252a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.0"
   async:
     dependency: transitive
     description:
@@ -53,18 +53,18 @@ packages:
     dependency: transitive
     description:
       name: cli_util
-      sha256: b8db3080e59b2503ca9e7922c3df2072cf13992354d5e944074ffa836fba43b7
+      sha256: c05b7406fdabc7a49a3929d4af76bcaccbbffcbcdcf185b082e1ae07da323d19
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.0"
+    version: "0.4.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   conventional_commit:
     dependency: transitive
     description:
@@ -101,26 +101,26 @@ packages:
     dependency: transitive
     description:
       name: graphs
-      sha256: aedc5a15e78fc65a6e23bcd927f24c64dd995062bcd1ca6eda65a3cff92a4d19
+      sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   http:
     dependency: transitive
     description:
       name: http
-      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
+      sha256: b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.2"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      sha256: "40f592dd352890c3b60fec1b68e786cefb9603e05ff303dbc4dda49b304ecdf4"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.0"
   io:
     dependency: transitive
     description:
@@ -133,10 +133,10 @@ packages:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467
+      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.1"
+    version: "4.9.0"
   lints:
     dependency: transitive
     description:
@@ -149,26 +149,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   melos:
     dependency: "direct dev"
     description:
       name: melos
-      sha256: "3f22f6cc629d72acf3acc8a7f8563384550290fa30790efa328c9cf606aa17d7"
+      sha256: "96e64bbade5712c3f010137e195bca9f1b351fac34ab1f322af492ae34032067"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.4.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.15.0"
   mustache_template:
     dependency: transitive
     description:
@@ -181,18 +181,18 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   platform:
     dependency: transitive
     description:
       name: platform
-      sha256: ae68c7bfcd7383af3629daafb32fb4e8681c7154428da4febcff06200585f102
+      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.5"
   pool:
     dependency: transitive
     description:
@@ -277,10 +277,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   term_glyph:
     dependency: transitive
     description:
@@ -293,10 +293,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.3"
   typed_data:
     dependency: transitive
     description:
@@ -313,6 +313,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: d43c1d6b787bf0afad444700ae7f4db8827f701bc61c255ac8d328c6f4d52062
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   yaml:
     dependency: transitive
     description:
@@ -325,9 +333,9 @@ packages:
     dependency: transitive
     description:
       name: yaml_edit
-      sha256: "1579d4a0340a83cf9e4d580ea51a16329c916973bffd5bd4b45e911b25d46bfd"
+      sha256: e9c1a3543d2da0db3e90270dbb1e4eebc985ee5e3ffe468d83224472b2194a5f
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.2.1"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
+  dart: ">=3.4.0 <4.0.0"


### PR DESCRIPTION
**BugReproduce**:
- On iOS device
- Location Permission is enabled and granted. Performing `final connectedSSID = await WiFiForIoTPlugin.getSSID()` should see the current connectedSSID.
- iOS device is already connected to any available wifi.
- provide an unavailable SSID then perform `final isConnected = await WiFiForIoTPlugin.connect(wrongSSID);` -> iOS System dialog is showing to indicate the connection is failed -> expecting `isConnected` is [false] but get [true]

**RootCause**
- **Where**: packages/wifi_iot/ios/Classes/SwiftWifiIotPlugin.swift: `private func connect(call: FlutterMethodCall, result: @escaping FlutterResult)`
- **How**: The way to determine isConnected is that, after connect(targetSSID) is performed, then getSSID to get connectedSSID, checking if targetSSID is equal to connectedSSID. 
- **What**: In the original code base, because of the confused naming, it only unwrapped the connectedSSID ( original `sSSID`, after unwrapping `ssid` ) and returned as result by comparing itself ( original `result(ssid == sSSID)` ). In this case, once the device is already connected to a ssid, getSSID() works correctly, then getSSID() will return the connectedSSID, unwrapping connectedSSID, comparing itself as the result, it will be always true. It leads connect(targetSSID) returns true, even if the connection is actually failed.

**Solution**
- Renaming the parameter of getSSID closure: sSSID -> `connectedSSID`
- Check if targetSSID is equal to connectedSSID: `result(sSSID == connectedSSID)`