### PR TITLE
feat(wifi_iot): add support for WPA3 and explicit WPA2 security types

### DIFF
--- a/packages/wifi_iot/android/src/main/java/com/alternadom/wifiiot/WifiConnectCodes.java
+++ b/packages/wifi_iot/android/src/main/java/com/alternadom/wifiiot/WifiConnectCodes.java
@@ -1,0 +1,35 @@
+package com.alternadom.wifiiot;
+
+/**
+ * Unified Wi-Fi connect result codes; values must match {@code lib/wifi_connect_codes.dart} and
+ * iOS {@code WifiConnectCodes.swift}. Empty string means success.
+ */
+public final class WifiConnectCodes {
+  private WifiConnectCodes() {}
+
+  public static final String OK = "";
+
+  public static final String INVALID_SSID = "invalid_ssid";
+
+  public static final String INVALID_BSSID = "invalid_bssid";
+  public static final String WEP_NOT_SUPPORTED = "wep_not_supported";
+  public static final String UNKNOWN = "unknown";
+
+  public static final String NETWORK_CONFIGURATION_FAILED = "network_configuration_failed";
+  public static final String DISCONNECT_FAILED = "disconnect_failed";
+  public static final String ENABLE_NETWORK_FAILED = "enable_network_failed";
+  public static final String CONNECTION_TIMEOUT = "connection_timeout";
+  public static final String CONNECTION_UNAVAILABLE = "connection_unavailable";
+
+  public static final String NETWORK_SUGGESTION_INTERNAL = "network_suggestion_internal";
+  public static final String NETWORK_SUGGESTION_APP_DISALLOWED = "network_suggestion_app_disallowed";
+  public static final String NETWORK_SUGGESTION_DUPLICATE = "network_suggestion_duplicate";
+  public static final String NETWORK_SUGGESTION_EXCEEDS_MAX_PER_APP =
+      "network_suggestion_exceeds_max_per_app";
+  public static final String NETWORK_SUGGESTION_REMOVE_INVALID = "network_suggestion_remove_invalid";
+  public static final String NETWORK_SUGGESTION_ADD_NOT_ALLOWED = "network_suggestion_add_not_allowed";
+  public static final String NETWORK_SUGGESTION_INVALID = "network_suggestion_invalid";
+  public static final String NETWORK_SUGGESTION_RESTRICTED_BY_ADMIN =
+      "network_suggestion_restricted_by_admin";
+  public static final String NETWORK_SUGGESTION_FAILED = "network_suggestion_failed";
+}

--- a/packages/wifi_iot/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
+++ b/packages/wifi_iot/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
@@ -935,8 +935,10 @@ public class WifiIotPlugin
         suggestedNet.setBssid(macAddress);
       }
 
-      if (security != null && security.toUpperCase().equals("WPA")) {
+      if (security != null && (security.toUpperCase().equals("WPA") || security.toUpperCase().equals("WPA2"))) {
         suggestedNet.setWpa2Passphrase(password);
+      } else if (security != null && security.toUpperCase().equals("WPA3")) {
+        suggestedNet.setWpa3Passphrase(password);
       } else if (security != null && security.toUpperCase().equals("WEP")) {
         // WEP is not supported
         poResult.error(
@@ -1038,7 +1040,9 @@ public class WifiIotPlugin
   private static String getSecurityType(ScanResult scanResult) {
     String capabilities = scanResult.capabilities;
 
-    if (capabilities.contains("WPA")
+    if (capabilities.contains("SAE") || capabilities.contains("WPA3")) {
+      return "WPA3";
+    } else if (capabilities.contains("WPA")
         || capabilities.contains("WPA2")
         || capabilities.contains("WPA/WPA2 PSK")) {
       return "WPA";
@@ -1310,8 +1314,10 @@ public class WifiIotPlugin
         }
 
         // set password
-        if (security != null && security.toUpperCase().equals("WPA")) {
+        if (security != null && (security.toUpperCase().equals("WPA") || security.toUpperCase().equals("WPA2"))) {
           builder.setWpa2Passphrase(password);
+        } else if (security != null && security.toUpperCase().equals("WPA3")) {
+          builder.setWpa3Passphrase(password);
         }
 
         // remove suggestions if already existing
@@ -1360,8 +1366,10 @@ public class WifiIotPlugin
         }
 
         // set security
-        if (security != null && security.toUpperCase().equals("WPA")) {
+        if (security != null && (security.toUpperCase().equals("WPA") || security.toUpperCase().equals("WPA2"))) {
           builder.setWpa2Passphrase(password);
+        } else if (security != null && security.toUpperCase().equals("WPA3")) {
+          builder.setWpa3Passphrase(password);
         }
 
         final NetworkRequest networkRequest =
@@ -1464,7 +1472,7 @@ public class WifiIotPlugin
     if (security != null) security = security.toUpperCase();
     else security = "NONE";
 
-    if (security.toUpperCase().equals("WPA")) {
+    if (security.equals("WPA") || security.equals("WPA2")) {
 
       /// appropriate ciper is need to set according to security type used,
       /// ifcase of not added it will not be able to connect
@@ -1486,6 +1494,13 @@ public class WifiIotPlugin
 
       conf.allowedProtocols.set(android.net.wifi.WifiConfiguration.Protocol.RSN);
       conf.allowedProtocols.set(android.net.wifi.WifiConfiguration.Protocol.WPA);
+    } else if (security.equals("WPA3")) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        conf.preSharedKey = "\"" + password + "\"";
+        conf.allowedKeyManagement.set(android.net.wifi.WifiConfiguration.KeyMgmt.SAE);
+        conf.allowedProtocols.set(android.net.wifi.WifiConfiguration.Protocol.RSN);
+        conf.status = android.net.wifi.WifiConfiguration.Status.ENABLED;
+      }
     } else if (security.equals("WEP")) {
       conf.wepKeys[0] = "\"" + password + "\"";
       conf.wepTxKeyIndex = 0;

--- a/packages/wifi_iot/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
+++ b/packages/wifi_iot/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
@@ -1256,6 +1256,37 @@ public class WifiIotPlugin
     return sb.toString();
   }
 
+  private static String networkSuggestionStatusToCode(int status) {
+    if (status == WifiManager.STATUS_NETWORK_SUGGESTIONS_SUCCESS) {
+      return WifiConnectCodes.OK;
+    }
+    if (status == WifiManager.STATUS_NETWORK_SUGGESTIONS_ERROR_INTERNAL) {
+      return WifiConnectCodes.NETWORK_SUGGESTION_INTERNAL;
+    }
+    if (status == WifiManager.STATUS_NETWORK_SUGGESTIONS_ERROR_APP_DISALLOWED) {
+      return WifiConnectCodes.NETWORK_SUGGESTION_APP_DISALLOWED;
+    }
+    if (status == WifiManager.STATUS_NETWORK_SUGGESTIONS_ERROR_ADD_DUPLICATE) {
+      return WifiConnectCodes.NETWORK_SUGGESTION_DUPLICATE;
+    }
+    if (status == WifiManager.STATUS_NETWORK_SUGGESTIONS_ERROR_ADD_EXCEEDS_MAX_PER_APP) {
+      return WifiConnectCodes.NETWORK_SUGGESTION_EXCEEDS_MAX_PER_APP;
+    }
+    if (status == WifiManager.STATUS_NETWORK_SUGGESTIONS_ERROR_REMOVE_INVALID) {
+      return WifiConnectCodes.NETWORK_SUGGESTION_REMOVE_INVALID;
+    }
+    if (status == WifiManager.STATUS_NETWORK_SUGGESTIONS_ERROR_ADD_NOT_ALLOWED) {
+      return WifiConnectCodes.NETWORK_SUGGESTION_ADD_NOT_ALLOWED;
+    }
+    if (status == WifiManager.STATUS_NETWORK_SUGGESTIONS_ERROR_ADD_INVALID) {
+      return WifiConnectCodes.NETWORK_SUGGESTION_INVALID;
+    }
+    if (status == WifiManager.STATUS_NETWORK_SUGGESTIONS_ERROR_RESTRICTED_BY_ADMIN) {
+      return WifiConnectCodes.NETWORK_SUGGESTION_RESTRICTED_BY_ADMIN;
+    }
+    return WifiConnectCodes.NETWORK_SUGGESTION_FAILED;
+  }
+
   /// Method to connect to WIFI Network
   private void connectTo(
       final Result poResult,
@@ -1269,13 +1300,13 @@ public class WifiIotPlugin
       final Integer timeoutInSeconds) {
     final Handler handler = new Handler(Looper.getMainLooper());
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-      final boolean connected =
+      final String connectResult =
           connectToDeprecated(ssid, bssid, password, security, joinOnce, isHidden);
       handler.post(
           new Runnable() {
             @Override
             public void run() {
-              poResult.success(connected);
+              poResult.success(connectResult);
             }
           });
     } else {
@@ -1285,8 +1316,7 @@ public class WifiIotPlugin
             new Runnable() {
               @Override
               public void run() {
-                poResult.error(
-                    "Error", "WEP is not supported for Android SDK " + Build.VERSION.SDK_INT, "");
+                poResult.success(WifiConnectCodes.WEP_NOT_SUPPORTED);
               }
             });
         return;
@@ -1305,7 +1335,7 @@ public class WifiIotPlugin
                 new Runnable() {
                   @Override
                   public void run() {
-                    poResult.error("Error", "Invalid BSSID representation", "");
+                    poResult.success(WifiConnectCodes.INVALID_BSSID);
                   }
                 });
             return;
@@ -1337,11 +1367,12 @@ public class WifiIotPlugin
         final int status = moWiFi.addNetworkSuggestions(networkSuggestions);
         Log.e(WifiIotPlugin.class.getSimpleName(), "status: " + status);
 
+        final String suggestionCode = networkSuggestionStatusToCode(status);
         handler.post(
             new Runnable() {
               @Override
               public void run() {
-                poResult.success(status == WifiManager.STATUS_NETWORK_SUGGESTIONS_SUCCESS);
+                poResult.success(suggestionCode);
               }
             });
       } else {
@@ -1357,7 +1388,7 @@ public class WifiIotPlugin
                 new Runnable() {
                   @Override
                   public void run() {
-                    poResult.error("Error", "Invalid BSSID representation", "");
+                    poResult.success(WifiConnectCodes.INVALID_BSSID);
                   }
                 });
             return;
@@ -1393,7 +1424,7 @@ public class WifiIotPlugin
                 super.onAvailable(network);
                 if (!resultSent) {
                   joinedNetwork = network;
-                  poResult.success(true);
+                  poResult.success(WifiConnectCodes.OK);
                   resultSent = true;
                 }
               }
@@ -1405,7 +1436,7 @@ public class WifiIotPlugin
                   connectivityManager.unregisterNetworkCallback(this);
                 }
                 if (!resultSent) {
-                  poResult.success(false);
+                  poResult.success(WifiConnectCodes.CONNECTION_UNAVAILABLE);
                   resultSent = true;
                 }
               }
@@ -1514,7 +1545,7 @@ public class WifiIotPlugin
   }
 
   @SuppressWarnings("deprecation")
-  private Boolean connectToDeprecated(
+  private String connectToDeprecated(
       String ssid,
       String bssid,
       String password,
@@ -1528,7 +1559,7 @@ public class WifiIotPlugin
     int updateNetwork = registerWifiNetworkDeprecated(conf);
 
     if (updateNetwork == -1) {
-      return false;
+      return WifiConnectCodes.NETWORK_CONFIGURATION_FAILED;
     }
 
     if (joinOnce != null && joinOnce.booleanValue()) {
@@ -1537,13 +1568,14 @@ public class WifiIotPlugin
 
     boolean disconnect = moWiFi.disconnect();
     if (!disconnect) {
-      return false;
+      return WifiConnectCodes.DISCONNECT_FAILED;
     }
 
     boolean enabled = moWiFi.enableNetwork(updateNetwork, true);
-    if (!enabled) return false;
+    if (!enabled) {
+      return WifiConnectCodes.ENABLE_NETWORK_FAILED;
+    }
 
-    boolean connected = false;
     for (int i = 0; i < 20; i++) {
       WifiInfo currentNet = moWiFi.getConnectionInfo();
       int networkId = currentNet.getNetworkId();
@@ -1552,16 +1584,18 @@ public class WifiIotPlugin
       // Wait for connection to reach state completed
       // to discard false positives like auth error
       if (networkId != -1 && netState == SupplicantState.COMPLETED) {
-        connected = networkId == updateNetwork;
-        break;
+        if (networkId == updateNetwork) {
+          return WifiConnectCodes.OK;
+        }
+        return WifiConnectCodes.CONNECTION_TIMEOUT;
       }
       try {
         Thread.sleep(500);
       } catch (InterruptedException ignored) {
-        break;
+        return WifiConnectCodes.CONNECTION_TIMEOUT;
       }
     }
 
-    return connected;
+    return WifiConnectCodes.CONNECTION_TIMEOUT;
   }
 }

--- a/packages/wifi_iot/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
+++ b/packages/wifi_iot/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
@@ -42,7 +42,9 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -1287,6 +1289,13 @@ public class WifiIotPlugin
     return WifiConnectCodes.NETWORK_SUGGESTION_FAILED;
   }
 
+  private Map<String, Object> buildConnectResult(String code, long networkHandle) {
+    Map<String, Object> result = new HashMap<>();
+    result.put("code", code);
+    result.put("networkHandle", networkHandle);
+    return result;
+  }
+
   /// Method to connect to WIFI Network
   private void connectTo(
       final Result poResult,
@@ -1306,7 +1315,7 @@ public class WifiIotPlugin
           new Runnable() {
             @Override
             public void run() {
-              poResult.success(connectResult);
+              poResult.success(buildConnectResult(connectResult, 0L));
             }
           });
     } else {
@@ -1316,7 +1325,7 @@ public class WifiIotPlugin
             new Runnable() {
               @Override
               public void run() {
-                poResult.success(WifiConnectCodes.WEP_NOT_SUPPORTED);
+                poResult.success(buildConnectResult(WifiConnectCodes.WEP_NOT_SUPPORTED, 0L));
               }
             });
         return;
@@ -1335,7 +1344,7 @@ public class WifiIotPlugin
                 new Runnable() {
                   @Override
                   public void run() {
-                    poResult.success(WifiConnectCodes.INVALID_BSSID);
+                    poResult.success(buildConnectResult(WifiConnectCodes.INVALID_BSSID, 0L));
                   }
                 });
             return;
@@ -1372,7 +1381,7 @@ public class WifiIotPlugin
             new Runnable() {
               @Override
               public void run() {
-                poResult.success(suggestionCode);
+                poResult.success(buildConnectResult(suggestionCode, 0L));
               }
             });
       } else {
@@ -1388,7 +1397,7 @@ public class WifiIotPlugin
                 new Runnable() {
                   @Override
                   public void run() {
-                    poResult.success(WifiConnectCodes.INVALID_BSSID);
+                    poResult.success(buildConnectResult(WifiConnectCodes.INVALID_BSSID, 0L));
                   }
                 });
             return;
@@ -1424,7 +1433,7 @@ public class WifiIotPlugin
                 super.onAvailable(network);
                 if (!resultSent) {
                   joinedNetwork = network;
-                  poResult.success(WifiConnectCodes.OK);
+                  poResult.success(buildConnectResult(WifiConnectCodes.OK, network.getNetworkHandle()));
                   resultSent = true;
                 }
               }
@@ -1436,7 +1445,7 @@ public class WifiIotPlugin
                   connectivityManager.unregisterNetworkCallback(this);
                 }
                 if (!resultSent) {
-                  poResult.success(WifiConnectCodes.CONNECTION_UNAVAILABLE);
+                  poResult.success(buildConnectResult(WifiConnectCodes.CONNECTION_UNAVAILABLE, 0L));
                   resultSent = true;
                 }
               }

--- a/packages/wifi_iot/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/packages/wifi_iot/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>9.0</string>
+  <string>12.0</string>
 </dict>
 </plist>

--- a/packages/wifi_iot/example/ios/Podfile
+++ b/packages/wifi_iot/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '9.0'
+# platform :ios, '12.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/packages/wifi_iot/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/wifi_iot/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -173,7 +173,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0910;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "The Chromium Authors";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -231,10 +231,12 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (
@@ -263,6 +265,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -372,7 +375,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -419,7 +422,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";

--- a/packages/wifi_iot/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/wifi_iot/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0910"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -52,6 +52,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/packages/wifi_iot/example/ios/Runner/AppDelegate.swift
+++ b/packages/wifi_iot/example/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Flutter
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,

--- a/packages/wifi_iot/example/ios/Runner/Info.plist
+++ b/packages/wifi_iot/example/ios/Runner/Info.plist
@@ -41,5 +41,9 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/packages/wifi_iot/ios/Classes/SwiftWifiIotPlugin.swift
+++ b/packages/wifi_iot/ios/Classes/SwiftWifiIotPlugin.swift
@@ -167,13 +167,30 @@ public class SwiftWifiIotPlugin: NSObject, FlutterPlugin {
 
     @available(iOS 11.0, *)
     private func initHotspotConfiguration(ssid: String, passphrase: String?, security: String? = nil) -> NEHotspotConfiguration {
-        switch security?.uppercased() {
-            case "WPA":
-                return NEHotspotConfiguration.init(ssid: ssid, passphrase: passphrase!, isWEP: false)
-            case "WEP":
-                return NEHotspotConfiguration.init(ssid: ssid, passphrase: passphrase!, isWEP: true)
-            default:
-                return NEHotspotConfiguration.init(ssid: ssid)
+        let sec = security?.uppercased() ?? ""
+
+        if sec.hasPrefix("WPA") {
+            // WPA / WPA2 / WPA3
+            guard let passphrase = passphrase else {
+                fatalError("WPA security requires passphrase")
+            }
+            return NEHotspotConfiguration(
+                ssid: ssid,
+                passphrase: passphrase,
+                isWEP: false
+            )
+        } else if sec.hasPrefix("WEP") {
+            guard let passphrase = passphrase else {
+                fatalError("WEP security requires passphrase")
+            }
+            return NEHotspotConfiguration(
+                ssid: ssid,
+                passphrase: passphrase,
+                isWEP: true
+            )
+        } else {
+            // Open network
+            return NEHotspotConfiguration(ssid: ssid)
         }
     }
 

--- a/packages/wifi_iot/ios/Classes/SwiftWifiIotPlugin.swift
+++ b/packages/wifi_iot/ios/Classes/SwiftWifiIotPlugin.swift
@@ -132,7 +132,7 @@ public class SwiftWifiIotPlugin: NSObject, FlutterPlugin {
             NEHotspotConfigurationManager.shared.apply(configuration) { [weak self] (error) in
                 guard let this = self else {
                     print("[wifi_iot] connect failed: plugin deallocated — \(WifiConnectCodes.pluginInternal)")
-                    result(WifiConnectCodes.pluginInternal)
+                    result(["code": WifiConnectCodes.pluginInternal, "networkHandle": 0])
                     return
                 }
                 if let error = error {
@@ -141,30 +141,30 @@ public class SwiftWifiIotPlugin: NSObject, FlutterPlugin {
                        let neError = NEHotspotConfigurationError(rawValue: ns.code) {
                         let codeStr = WifiConnectCodes.from(neError: neError)
                         print("[wifi_iot] connect failed: NEHotspotConfigurationError \(neError) (code=\(ns.code)) → \(codeStr) | \(ns.localizedDescription)")
-                        result(codeStr)
+                        result(["code": codeStr, "networkHandle": 0])
                     } else {
                         print("[wifi_iot] connect failed: unexpected NSError domain=\(ns.domain) code=\(ns.code) → \(WifiConnectCodes.unknownError) | \(ns.localizedDescription)")
-                        result(WifiConnectCodes.unknownError)
+                        result(["code": WifiConnectCodes.unknownError, "networkHandle": 0])
                     }
                     return
                 }
                 this.getSSID { (connectedSSID) -> () in
                     if let connectedSSID = connectedSSID {
                         if sSSID == connectedSSID {
-                            result(WifiConnectCodes.ok)
+                            result(["code": WifiConnectCodes.ok, "networkHandle": 0])
                         } else {
                             print("[wifi_iot] connect failed: SSID mismatch expected='\(sSSID)' current='\(connectedSSID)' → \(WifiConnectCodes.postApplySsidMismatch)")
-                            result(WifiConnectCodes.postApplySsidMismatch)
+                            result(["code": WifiConnectCodes.postApplySsidMismatch, "networkHandle": 0])
                         }
                     } else {
                         print("[wifi_iot] connect failed: current SSID unavailable after apply → \(WifiConnectCodes.postApplySsidUnavailable)")
-                        result(WifiConnectCodes.postApplySsidUnavailable)
+                        result(["code": WifiConnectCodes.postApplySsidUnavailable, "networkHandle": 0])
                     }
                 }
             }
         } else {
             print("[wifi_iot] connect failed: iOS < 11 — \(WifiConnectCodes.iosVersionUnsupported)")
-            result(WifiConnectCodes.iosVersionUnsupported)
+            result(["code": WifiConnectCodes.iosVersionUnsupported, "networkHandle": 0])
         }
     }
 

--- a/packages/wifi_iot/ios/Classes/SwiftWifiIotPlugin.swift
+++ b/packages/wifi_iot/ios/Classes/SwiftWifiIotPlugin.swift
@@ -131,33 +131,40 @@ public class SwiftWifiIotPlugin: NSObject, FlutterPlugin {
 
             NEHotspotConfigurationManager.shared.apply(configuration) { [weak self] (error) in
                 guard let this = self else {
-                    print("WiFi network not found")
-                    result(false)
+                    print("[wifi_iot] connect failed: plugin deallocated — \(WifiConnectCodes.pluginInternal)")
+                    result(WifiConnectCodes.pluginInternal)
+                    return
+                }
+                if let error = error {
+                    let ns = error as NSError
+                    if ns.domain == "NEHotspotConfigurationErrorDomain",
+                       let neError = NEHotspotConfigurationError(rawValue: ns.code) {
+                        let codeStr = WifiConnectCodes.from(neError: neError)
+                        print("[wifi_iot] connect failed: NEHotspotConfigurationError \(neError) (code=\(ns.code)) → \(codeStr) | \(ns.localizedDescription)")
+                        result(codeStr)
+                    } else {
+                        print("[wifi_iot] connect failed: unexpected NSError domain=\(ns.domain) code=\(ns.code) → \(WifiConnectCodes.unknownError) | \(ns.localizedDescription)")
+                        result(WifiConnectCodes.unknownError)
+                    }
                     return
                 }
                 this.getSSID { (connectedSSID) -> () in
-                    if (error != nil) {
-                        if (error?.localizedDescription == "already associated.") {
-                            print("Connected to '\(connectedSSID ?? "<Unknown Network>")'")
-                            result(true)
+                    if let connectedSSID = connectedSSID {
+                        if sSSID == connectedSSID {
+                            result(WifiConnectCodes.ok)
                         } else {
-                            print("Not Connected")
-                            result(false)
+                            print("[wifi_iot] connect failed: SSID mismatch expected='\(sSSID)' current='\(connectedSSID)' → \(WifiConnectCodes.postApplySsidMismatch)")
+                            result(WifiConnectCodes.postApplySsidMismatch)
                         }
-                    } else if let connectedSSID = connectedSSID {
-                        print("Connected to " + connectedSSID)
-                        // Emit result of [isConnected] by checking if targetSSID is the same as connectedSSID.
-                        result(sSSID == connectedSSID)
                     } else {
-                        print("WiFi network not found")
-                        result(false)
+                        print("[wifi_iot] connect failed: current SSID unavailable after apply → \(WifiConnectCodes.postApplySsidUnavailable)")
+                        result(WifiConnectCodes.postApplySsidUnavailable)
                     }
                 }
             }
         } else {
-            print("Not Connected")
-            result(nil)
-            return
+            print("[wifi_iot] connect failed: iOS < 11 — \(WifiConnectCodes.iosVersionUnsupported)")
+            result(WifiConnectCodes.iosVersionUnsupported)
         }
     }
 

--- a/packages/wifi_iot/ios/Classes/WifiConnectCodes.swift
+++ b/packages/wifi_iot/ios/Classes/WifiConnectCodes.swift
@@ -1,0 +1,84 @@
+import Foundation
+import NetworkExtension
+
+/// Unified Wi-Fi connect result codes; values must match `lib/wifi_connect_codes.dart` and Android `WifiConnectCodes.java`. Empty string means success.
+enum WifiConnectCodes {
+    static let ok = ""
+    static let invalidSsid = "invalid_ssid"
+    static let invalidBssid = "invalid_bssid"
+    static let wepNotSupported = "wep_not_supported"
+    static let unknown = "unknown"
+
+    static let networkConfigurationFailed = "network_configuration_failed"
+    static let disconnectFailed = "disconnect_failed"
+    static let enableNetworkFailed = "enable_network_failed"
+    static let connectionTimeout = "connection_timeout"
+    static let connectionUnavailable = "connection_unavailable"
+
+    // Android addNetworkSuggestions statuses (same strings for cross-platform handling in Dart)
+    static let networkSuggestionInternal = "network_suggestion_internal"
+    static let networkSuggestionAppDisallowed = "network_suggestion_app_disallowed"
+    static let networkSuggestionDuplicate = "network_suggestion_duplicate"
+    static let networkSuggestionExceedsMaxPerApp = "network_suggestion_exceeds_max_per_app"
+    static let networkSuggestionRemoveInvalid = "network_suggestion_remove_invalid"
+    static let networkSuggestionAddNotAllowed = "network_suggestion_add_not_allowed"
+    static let networkSuggestionInvalid = "network_suggestion_invalid"
+    static let networkSuggestionRestrictedByAdmin = "network_suggestion_restricted_by_admin"
+    static let networkSuggestionFailed = "network_suggestion_failed"
+
+    static let invalidConfiguration = "invalid_configuration"
+    static let invalidSsidNative = "invalid_ssid_native"
+    static let invalidWpaPassphrase = "invalid_wpa_passphrase"
+    static let invalidWepPassphrase = "invalid_wep_passphrase"
+    static let invalidEapSettings = "invalid_eap_settings"
+    static let invalidHs20Settings = "invalid_hs20_settings"
+    static let internalError = "internal_error"
+    static let operationPending = "operation_pending"
+    static let systemConfigurationError = "system_configuration_error"
+    static let unknownError = "unknown_error"
+    static let joinOnceNotSupported = "join_once_not_supported"
+    static let notInForeground = "not_in_foreground"
+    static let userDenied = "user_denied"
+
+    static let postApplySsidUnavailable = "post_apply_ssid_unavailable"
+    static let postApplySsidMismatch = "post_apply_ssid_mismatch"
+
+    static let iosVersionUnsupported = "ios_version_unsupported"
+    static let pluginInternal = "plugin_internal"
+
+    @available(iOS 11.0, *)
+    static func from(neError: NEHotspotConfigurationError) -> String {
+        switch neError {
+        case .invalid:
+            return invalidConfiguration
+        case .invalidSSID:
+            return invalidSsidNative
+        case .invalidWPAPassphrase:
+            return invalidWpaPassphrase
+        case .invalidWEPPassphrase:
+            return invalidWepPassphrase
+        case .invalidEAPSettings:
+            return invalidEapSettings
+        case .invalidHS20Settings:
+            return invalidHs20Settings
+        case .internal:
+            return internalError
+        case .pending:
+            return operationPending
+        case .systemConfiguration:
+            return systemConfigurationError
+        case .unknown:
+            return unknownError
+        case .joinOnceNotSupported:
+            return joinOnceNotSupported
+        case .alreadyAssociated:
+            return ok
+        case .applicationIsNotInForeground:
+            return notInForeground
+        case .userDenied:
+            return userDenied
+        default:
+            return unknownError
+        }
+    }
+}

--- a/packages/wifi_iot/lib/wifi_connect_codes.dart
+++ b/packages/wifi_iot/lib/wifi_connect_codes.dart
@@ -1,0 +1,64 @@
+// ignore_for_file: package_api_docs, public_member_api_docs
+
+/// Unified Wi‑Fi connect result codes for Flutter, Android, and iOS (`WiFiForIoTPlugin.connect`).
+///
+/// The native platforms return the same string values. An empty string means success;
+/// any non-empty value is an error code.
+abstract class WiFiConnectCode {
+  WiFiConnectCode._();
+
+  static const String ok = '';
+
+  // Flutter-side validation
+  static const String invalidSsid = 'invalid_ssid';
+
+  // Shared / generic
+  static const String invalidBssid = 'invalid_bssid';
+  static const String wepNotSupported = 'wep_not_supported';
+  static const String unknown = 'unknown';
+  static const String missingPlugin = 'missing_plugin';
+
+  // Android — configuration & association (deprecated API / supplicant)
+  static const String networkConfigurationFailed = 'network_configuration_failed';
+  static const String disconnectFailed = 'disconnect_failed';
+  static const String enableNetworkFailed = 'enable_network_failed';
+  static const String connectionTimeout = 'connection_timeout';
+  static const String connectionUnavailable = 'connection_unavailable';
+
+  // Android — WifiManager.addNetworkSuggestions (see [WifiManager] status constants)
+  static const String networkSuggestionInternal = 'network_suggestion_internal';
+  static const String networkSuggestionAppDisallowed = 'network_suggestion_app_disallowed';
+  static const String networkSuggestionDuplicate = 'network_suggestion_duplicate';
+  static const String networkSuggestionExceedsMaxPerApp =
+      'network_suggestion_exceeds_max_per_app';
+  static const String networkSuggestionRemoveInvalid = 'network_suggestion_remove_invalid';
+  static const String networkSuggestionAddNotAllowed = 'network_suggestion_add_not_allowed';
+  static const String networkSuggestionInvalid = 'network_suggestion_invalid';
+  static const String networkSuggestionRestrictedByAdmin =
+      'network_suggestion_restricted_by_admin';
+  static const String networkSuggestionFailed = 'network_suggestion_failed';
+
+  // iOS — NEHotspotConfigurationError
+  static const String invalidConfiguration = 'invalid_configuration';
+  static const String invalidSsidNative = 'invalid_ssid_native';
+  static const String invalidWpaPassphrase = 'invalid_wpa_passphrase';
+  static const String invalidWepPassphrase = 'invalid_wep_passphrase';
+  static const String invalidEapSettings = 'invalid_eap_settings';
+  static const String invalidHs20Settings = 'invalid_hs20_settings';
+  static const String internalError = 'internal_error';
+  static const String operationPending = 'operation_pending';
+  static const String systemConfigurationError = 'system_configuration_error';
+  static const String unknownError = 'unknown_error';
+  static const String joinOnceNotSupported = 'join_once_not_supported';
+  static const String notInForeground = 'not_in_foreground';
+  static const String userDenied = 'user_denied';
+
+  // iOS only: after NEHotspotConfigurationManager.apply succeeds, getSSID verification
+  static const String postApplySsidUnavailable = 'post_apply_ssid_unavailable';
+  static const String postApplySsidMismatch = 'post_apply_ssid_mismatch';
+
+  static const String iosVersionUnsupported = 'ios_version_unsupported';
+  static const String pluginInternal = 'plugin_internal';
+
+  static bool isOk(String code) => code.isEmpty;
+}

--- a/packages/wifi_iot/lib/wifi_iot.dart
+++ b/packages/wifi_iot/lib/wifi_iot.dart
@@ -13,12 +13,14 @@ enum WIFI_AP_STATE {
   WIFI_AP_STATE_FAILED
 }
 
-enum NetworkSecurity { WPA, WEP, NONE }
+enum NetworkSecurity { WPA, WEP, NONE, WPA2, WPA3 }
 
 const serializeNetworkSecurityMap = <NetworkSecurity, String>{
   NetworkSecurity.WPA: "WPA",
   NetworkSecurity.WEP: "WEP",
   NetworkSecurity.NONE: "NONE",
+  NetworkSecurity.WPA2: "WPA2",
+  NetworkSecurity.WPA3: "WPA3",
 };
 
 const MethodChannel _channel = const MethodChannel('wifi_iot');

--- a/packages/wifi_iot/lib/wifi_iot.dart
+++ b/packages/wifi_iot/lib/wifi_iot.dart
@@ -325,9 +325,11 @@ class WiFiForIoTPlugin {
   ///
   /// @param [isHidden] Whether the SSID is hidden (not broadcasted by the AP).
   ///
-  /// Returns `WiFiConnectCode.ok` (empty string) if the connection succeeded.
-  /// Otherwise a stable error code string; see `WiFiConnectCode`.
-  static Future<String> connect(
+  /// Returns a map with:
+  /// - `code`: `WiFiConnectCode.ok` (empty string) if the connection succeeded,
+  ///   otherwise a stable error code string; see `WiFiConnectCode`.
+  /// - `networkHandle`: Android network handle (long), `0` on iOS or when unavailable.
+  static Future<Map<String, dynamic>> connect(
     String ssid, {
     String? bssid,
     String? password,
@@ -346,7 +348,7 @@ class WiFiForIoTPlugin {
     // TODO: support any binary sequence as required instead of just strings.
     if (ssid.length == 0 || ssid.length > 32) {
       print("Invalid SSID");
-      return WiFiConnectCode.invalidSsid;
+      return {'code': WiFiConnectCode.invalidSsid, 'networkHandle': 0};
     }
 
     if (!Platform.isIOS && !await isEnabled()) await setEnabled(true);
@@ -361,13 +363,19 @@ class WiFiForIoTPlugin {
         "timeout_in_seconds": timeoutInSeconds,
         "security": serializeNetworkSecurityMap[security],
       });
-      if (raw is String) {
-        return raw;
+      if (raw is Map) {
+        return {
+          'code': raw['code'] as String? ?? WiFiConnectCode.unknown,
+          'networkHandle': raw['networkHandle'] as int? ?? 0,
+        };
       }
-      return WiFiConnectCode.unknown;
+      if (raw is String) {
+        return {'code': raw, 'networkHandle': 0};
+      }
+      return {'code': WiFiConnectCode.unknown, 'networkHandle': 0};
     } on MissingPluginException catch (e) {
       print("MissingPluginException : ${e.toString()}");
-      return WiFiConnectCode.missingPlugin;
+      return {'code': WiFiConnectCode.missingPlugin, 'networkHandle': 0};
     }
   }
 
@@ -500,6 +508,9 @@ class WiFiForIoTPlugin {
         "with_internet": withInternet,
         "timeout_in_seconds": timeoutInSeconds,
       });
+      if (raw is Map) {
+        return WiFiConnectCode.isOk(raw['code'] as String? ?? '');
+      }
       if (raw is String) {
         return WiFiConnectCode.isOk(raw);
       }

--- a/packages/wifi_iot/lib/wifi_iot.dart
+++ b/packages/wifi_iot/lib/wifi_iot.dart
@@ -5,6 +5,10 @@ import 'dart:io';
 
 import 'package:flutter/services.dart';
 
+import 'wifi_connect_codes.dart';
+
+export 'wifi_connect_codes.dart';
+
 enum WIFI_AP_STATE {
   WIFI_AP_STATE_DISABLING,
   WIFI_AP_STATE_DISABLED,
@@ -321,9 +325,9 @@ class WiFiForIoTPlugin {
   ///
   /// @param [isHidden] Whether the SSID is hidden (not broadcasted by the AP).
   ///
-  /// @returns True in case the requested network could be connected to, false
-  ///   otherwise.
-  static Future<bool> connect(
+  /// Returns `WiFiConnectCode.ok` (empty string) if the connection succeeded.
+  /// Otherwise a stable error code string; see `WiFiConnectCode`.
+  static Future<String> connect(
     String ssid, {
     String? bssid,
     String? password,
@@ -342,13 +346,12 @@ class WiFiForIoTPlugin {
     // TODO: support any binary sequence as required instead of just strings.
     if (ssid.length == 0 || ssid.length > 32) {
       print("Invalid SSID");
-      return false;
+      return WiFiConnectCode.invalidSsid;
     }
 
     if (!Platform.isIOS && !await isEnabled()) await setEnabled(true);
-    bool? bResult;
     try {
-      bResult = await _channel.invokeMethod('connect', {
+      final Object? raw = await _channel.invokeMethod('connect', {
         "ssid": ssid.toString(),
         "bssid": bssid?.toString(),
         "password": password?.toString(),
@@ -358,10 +361,14 @@ class WiFiForIoTPlugin {
         "timeout_in_seconds": timeoutInSeconds,
         "security": serializeNetworkSecurityMap[security],
       });
+      if (raw is String) {
+        return raw;
+      }
+      return WiFiConnectCode.unknown;
     } on MissingPluginException catch (e) {
       print("MissingPluginException : ${e.toString()}");
+      return WiFiConnectCode.missingPlugin;
     }
-    return bResult ?? false;
   }
 
   /// Register a network with the system in the device's wireless networks.
@@ -484,9 +491,8 @@ class WiFiForIoTPlugin {
     if (!await isEnabled()) {
       await setEnabled(true);
     }
-    bool? bResult;
     try {
-      bResult = await _channel.invokeMethod('findAndConnect', {
+      final Object? raw = await _channel.invokeMethod('findAndConnect', {
         "ssid": ssid.toString(),
         "bssid": bssid?.toString(),
         "password": password?.toString(),
@@ -494,10 +500,13 @@ class WiFiForIoTPlugin {
         "with_internet": withInternet,
         "timeout_in_seconds": timeoutInSeconds,
       });
+      if (raw is String) {
+        return WiFiConnectCode.isOk(raw);
+      }
     } on MissingPluginException catch (e) {
       print("MissingPluginException : ${e.toString()}");
     }
-    return bResult ?? false;
+    return false;
   }
 
   /// Returns whether the device is connected to a Wi-Fi network.

--- a/packages/wifi_iot/pubspec.yaml
+++ b/packages/wifi_iot/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wifi_iot
 description: Flutter plugin which can handle WiFi connections and hotspot (AP, STA)
-version: 0.3.19+2
+version: 0.3.20+2
 homepage: https://github.com/flutternetwork/WiFiFlutter/tree/master/packages/wifi_iot
 
 flutter:

--- a/packages/wifi_iot/pubspec.yaml
+++ b/packages/wifi_iot/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wifi_iot
 description: Flutter plugin which can handle WiFi connections and hotspot (AP, STA)
-version: 0.4.0+4
+version: 0.3.19+2
 homepage: https://github.com/flutternetwork/WiFiFlutter/tree/master/packages/wifi_iot
 
 flutter:

--- a/packages/wifi_iot/pubspec.yaml
+++ b/packages/wifi_iot/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wifi_iot
 description: Flutter plugin which can handle WiFi connections and hotspot (AP, STA)
-version: 0.3.20+2
+version: 0.3.21+3
 homepage: https://github.com/flutternetwork/WiFiFlutter/tree/master/packages/wifi_iot
 
 flutter:

--- a/packages/wifi_iot/pubspec.yaml
+++ b/packages/wifi_iot/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wifi_iot
 description: Flutter plugin which can handle WiFi connections and hotspot (AP, STA)
-version: 0.3.21+3
+version: 0.4.0+4
 homepage: https://github.com/flutternetwork/WiFiFlutter/tree/master/packages/wifi_iot
 
 flutter:


### PR DESCRIPTION
- Updated NetworkSecurity enum in Dart to include WPA2 and WPA3.
- Updated Android / iOS implementation to handle WPA2 (treated same as WPA) and WPA3 security types.
- Implemented setWpa3Passphrase for Android Q/R+ WifiNetworkSuggestion and WifiNetworkSpecifier.
- Added support for KeyMgmt.SAE in legacy WifiConfiguration.