### PR TITLE
fix(wifi_iot): iOS removeWiFiNetwork fix parameter name

### DIFF
--- a/packages/wifi_iot/ios/Classes/SwiftWifiIotPlugin.swift
+++ b/packages/wifi_iot/ios/Classes/SwiftWifiIotPlugin.swift
@@ -304,7 +304,7 @@ public class SwiftWifiIotPlugin: NSObject, FlutterPlugin {
 
     private func removeWifiNetwork(call: FlutterMethodCall, result: @escaping FlutterResult) {
         let arguments = call.arguments
-        let sPrefixSSID = (arguments as! [String : String])["prefix_ssid"] ?? ""
+        let sPrefixSSID = (arguments as! [String : String])["ssid"] ?? ""
         if (sPrefixSSID == "") {
             print("No prefix SSID was given!")
             result(nil)


### PR DESCRIPTION
For removeWiFiNetwork, the parameter passed into the plugins is "ssid", but the iOS plugin was expecting "prefix_ssid", resulting in the "No prefix SSID was given!" print.
Corrected the parameter name to "ssid".