### PR TITLE
fix(wifi_iot): jcenter is discontinued, replace jcenter()

### DIFF
--- a/packages/wifi_iot/android/build.gradle
+++ b/packages/wifi_iot/android/build.gradle
@@ -4,7 +4,7 @@ version '1.0-SNAPSHOT'
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -15,7 +15,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/packages/wifi_iot/example/android/build.gradle
+++ b/packages/wifi_iot/example/android/build.gradle
@@ -2,7 +2,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 }
 


### PR DESCRIPTION
fix(wifi_iot): jcenter is discontinued, replace jcenter() with mavenCentral().

https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

jcenter() removed entirely in gradle 9.x